### PR TITLE
Implement deadzone adjustment

### DIFF
--- a/fw/analog_turntable.c
+++ b/fw/analog_turntable.c
@@ -21,9 +21,9 @@ int8_t analog_turntable_poll(analog_turntable* self, uint32_t current_value) {
 
   // is the current value sufficiently far away from the center?
   uint8_t direction = 0;
-  if (delta >= (int32_t)self->deadzone) {
+  if (delta >= (int8_t)self->deadzone) {
     direction = 1;
-  } else if (delta <= -(int32_t)self->deadzone) {
+  } else if (delta <= -(int8_t)self->deadzone) {
     direction = -1;
   }
 

--- a/fw/analog_turntable.c
+++ b/fw/analog_turntable.c
@@ -1,0 +1,49 @@
+#include "analog_turntable.h"
+
+void analog_turntable_init(analog_turntable* self, uint8_t deadzone, uint32_t sustain_ms, bool clear) {
+  self->deadzone = deadzone;
+  self->sustain_ms = sustain_ms;
+  self->clear = clear;
+  self->center = 0;
+  self->center_valid = false;
+  self->state = 0;
+  timer_init(&self->sustain_timer);
+}
+
+int8_t analog_turntable_poll(analog_turntable* self, uint32_t current_value) {
+  if (!self->center_valid) {
+    self->center_valid = true;
+    self->center = current_value;
+  }
+
+  uint8_t observed = current_value;
+  int8_t delta = observed - self->center;
+
+  // is the current value sufficiently far away from the center?
+  uint8_t direction = 0;
+  if (delta >= (int32_t)self->deadzone) {
+    direction = 1;
+  } else if (delta <= -(int32_t)self->deadzone) {
+    direction = -1;
+  }
+
+  if (direction != 0) {
+    // turntable is moving
+    // keep updating the new center, and keep extending the sustain timer
+    self->center = observed;
+    timer_arm(&self->sustain_timer, self->sustain_ms);
+  } else if (timer_check_if_expired_reset(&self->sustain_timer)) {
+    // sustain timer expired, time to reset to neutral
+    self->state = 0;
+    self->center = observed;
+  }
+
+  if (direction == -self->state && self->clear) {
+    self->state = direction;
+    return 0;
+  } else if (direction != 0) {
+    self->state = direction;
+  }
+
+  return self->state;
+}

--- a/fw/analog_turntable.h
+++ b/fw/analog_turntable.h
@@ -4,7 +4,7 @@
 
 typedef struct {
   // Number of ticks we need to advance before recognizing an input
-  uint32_t deadzone;
+  uint8_t deadzone;
   // How long to sustain the input before clearing it (if opposite direction is input, we'll release immediately)
   uint32_t sustain_ms;
   // Always provide a zero-input for one poll before reversing?
@@ -19,51 +19,7 @@ typedef struct {
 
   int8_t state; // -1, 0, 1
 } analog_turntable;
+analog_turntable tt1;
 
-void analog_turntable_init(analog_turntable* self, uint32_t deadzone, uint32_t sustain_ms, bool clear) {
-  self->deadzone = deadzone;
-  self->sustain_ms = sustain_ms;
-  self->clear = clear;
-  self->center = 0;
-  self->center_valid = false;
-  self->state = 0;
-  timer_init(&self->sustain_timer);
-}
-
-int8_t analog_turntable_poll(analog_turntable* self, uint32_t current_value) {
-  if (!self->center_valid) {
-    self->center_valid = true;
-    self->center = current_value;
-  }
-
-  uint8_t observed = current_value;
-  int8_t delta = observed - self->center;
-
-  // is the current value sufficiently far away from the center?
-  uint8_t direction = 0;
-  if (delta >= (int32_t)self->deadzone) {
-    direction = 1;
-  } else if (delta <= -(int32_t)self->deadzone) {
-    direction = -1;
-  }
-
-  if (direction != 0) {
-    // turntable is moving
-    // keep updating the new center, and keep extending the sustain timer
-    self->center = observed;
-    timer_arm(&self->sustain_timer, self->sustain_ms);
-  } else if (timer_check_if_expired_reset(&self->sustain_timer)) {
-    // sustain timer expired, time to reset to neutral
-    self->state = 0;
-    self->center = observed;
-  }
-
-  if (direction == -self->state && self->clear) {
-    self->state = direction;
-    return 0;
-  } else if (direction != 0) {
-    self->state = direction;
-  }
-
-  return self->state;
-}
+void analog_turntable_init(analog_turntable* self, uint8_t deadzone, uint32_t sustain_ms, bool clear);
+int8_t analog_turntable_poll(analog_turntable* self, uint32_t current_value);

--- a/fw/beef.c
+++ b/fw/beef.c
@@ -55,7 +55,6 @@ typedef struct {
   void (*config_set)(config*);
 } combo;
 
-#define NUM_OF_COMBOS 2
 combo button_combos[NUM_OF_COMBOS] = {
   {
     button_combo: REVERSE_TT_COMBO,
@@ -65,6 +64,14 @@ combo button_combos[NUM_OF_COMBOS] = {
     button_combo: TT_EFFECTS_COMBO,
     config_set: cycle_tt_effects
   },
+  {
+    button_combo: TT_DEADZONE_INCR_COMBO,
+    config_set: increase_deadzone
+  },
+  {
+    button_combo: TT_DEADZONE_DECR_COMBO,
+    config_set: decrease_deadzone
+  },
 };
 
 ISR(TIMER1_COMPA_vect) {
@@ -73,6 +80,8 @@ ISR(TIMER1_COMPA_vect) {
 
 int main(void) {
   hwinit();
+
+  config_init(&current_config);
 
   timer_init(&led_timer);
 
@@ -85,11 +94,9 @@ int main(void) {
   timer combo_lights_timer;
   timer_init(&combo_timer);
   timer_init(&combo_lights_timer);
+  timer_init(&combo_tt_led_timer);
 
-  analog_turntable tt1;
-  analog_turntable_init(&tt1, 4, 200, true);
-
-  config_init(&current_config);
+  analog_turntable_init(&tt1, current_config.tt_deadzone, 200, true);
 
   // tt_x DATA lines wired to F0/F1
   DDRF  &= 0b11111100;
@@ -128,7 +135,8 @@ int main(void) {
     }
     process_combos(&current_config,
                    &combo_timer,
-                   &combo_lights_timer);
+                   &combo_lights_timer,
+                   &combo_tt_led_timer);
 
     process_tt(tt_x.PIN,
                tt_x.a_pin,
@@ -282,7 +290,8 @@ void process_button(volatile uint8_t* PIN,
 
 void process_combos(config* current_config,
                     timer* combo_timer,
-                    timer* combo_lights_timer) {
+                    timer* combo_lights_timer,
+                    timer* combo_tt_led_timer) {
   static bool ignore_combo = false;
   bool combo_pressed = false;
 
@@ -298,10 +307,9 @@ void process_combos(config* current_config,
         timer_arm(combo_timer, 1000);
       }
 
-      if (timer_is_expired(combo_timer)) {
+      if (timer_check_if_expired_reset(combo_timer)) {
         button_combos[i].config_set(current_config);
-        timer_init(combo_timer);
-        timer_arm(combo_lights_timer, 500);
+        timer_arm(combo_lights_timer, CONFIG_CHANGE_NOTIFY_TIME);
         ignore_combo = true;
       }
 
@@ -313,6 +321,7 @@ void process_combos(config* current_config,
     ignore_combo = false;
     timer_init(combo_timer);
     timer_init(combo_lights_timer);
+    timer_init(combo_tt_led_timer);
   }
 }
 

--- a/fw/beef.c
+++ b/fw/beef.c
@@ -120,8 +120,7 @@ int main(void) {
     HID_Task();
     USB_USBTask();
 
-    if (!timer_is_armed(&hid_lights_expiry_timer) ||
-        timer_check_if_expired_reset(&hid_lights_expiry_timer)) {
+    if (timer_check_if_expired_reset(&hid_lights_expiry_timer)) {
       reactive_led = true;
       set_hid_standby_lighting(&led_state_from_hid_report);
     }
@@ -375,8 +374,7 @@ void update_lighting(int8_t tt1_report,
 
 void update_button_lighting(uint16_t led_state,
                             timer* combo_lights_timer) {
-  if (timer_is_armed(combo_lights_timer) &&
-      !timer_check_if_expired_reset(combo_lights_timer)) {
+  if (timer_is_active(combo_lights_timer)) {
     // Temporarily black out button LEDs to notify a mode change
     led_state = 0;
   }

--- a/fw/beef.h
+++ b/fw/beef.h
@@ -38,7 +38,8 @@ void process_button(volatile uint8_t* PIN,
                     uint8_t input_pin);
 void process_combos(config* current_config,
                     timer* combo_timer,
-                    timer* combo_lights_timer);
+                    timer* combo_lights_timer,
+                    timer* combo_tt_led_timer);
 void process_tt(volatile uint8_t* PIN,
                 uint8_t a_pin,
                 uint8_t b_pin,

--- a/fw/config.c
+++ b/fw/config.c
@@ -1,8 +1,10 @@
-#define CONFIG_VERSION 1
+#define CONFIG_VERSION 2
+
 #define CONFIG_BASE_ADDR (uint8_t*)2
 #define CONFIG_VERSION_ADDR CONFIG_BASE_ADDR
 #define CONFIG_REVERSE_TT_ADDR (CONFIG_VERSION_ADDR + sizeof(uint8_t))
 #define CONFIG_TT_EFFECT_ADDR (CONFIG_REVERSE_TT_ADDR + sizeof(uint8_t))
+#define CONFIG_TT_DEADZONE_ADDR (CONFIG_TT_EFFECT_ADDR + sizeof(ring_light_mode))
 
 #define MAGIC 0xBEEF
 
@@ -10,6 +12,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "analog_turntable.h"
 #include "config.h"
 #include "tt_rgb_manager.h"
 
@@ -28,6 +31,7 @@ void config_init(config* self) {
     self->version = CONFIG_VERSION;
     self->reverse_tt = 0;
     self->tt_effect = SPIN;
+    self->tt_deadzone = 4;
   }
 
   update = update_config(self);
@@ -42,9 +46,12 @@ bool update_config(config* self) {
 
   switch (self->version) {
   case 0:
-    update = true;
     self->tt_effect = SPIN;
     self->version++;
+  case 1:
+    self->tt_deadzone = 4;
+    self->version++;
+    update = true;
   }
 
   return update;
@@ -53,6 +60,20 @@ bool update_config(config* self) {
 void toggle_reverse_tt(config* self) {
   self->reverse_tt ^= 1;
   eeprom_write_byte(CONFIG_REVERSE_TT_ADDR, self->reverse_tt);
+
+  // Illuminate + as blue, - as red in two halves
+  int offset = self->reverse_tt ? 0 : RING_LIGHT_LEDS / 2;
+  int blue_start = offset;
+  int blue_end = blue_start + (RING_LIGHT_LEDS / 2);
+  int red_start = (12 + offset) % RING_LIGHT_LEDS;
+  int red_end = red_start + (RING_LIGHT_LEDS / 2);
+  for (int i = blue_start; i < blue_end; ++i) {
+    rgb(&tt_leds[i], 0, 0, 255);
+  }
+  for (int i = red_start; i < red_end; ++i) {
+    rgb(&tt_leds[i], 255, 0, 0);
+  }
+  timer_arm(&combo_tt_led_timer, CONFIG_CHANGE_NOTIFY_TIME);
 }
 
 void cycle_tt_effects(config* self) {
@@ -65,5 +86,40 @@ void cycle_tt_effects(config* self) {
            self->tt_effect == RING_LIGHT_MODE_PLACEHOLDER5);
   eeprom_write_byte(CONFIG_TT_EFFECT_ADDR, self->tt_effect);
 
-  set_led_off();
+  set_tt_leds_off();
+}
+
+void display_tt_change(uint8_t deadzone, int range) {
+  int num_of_leds = deadzone * (RING_LIGHT_LEDS / range);
+  for (int i = 0; i < num_of_leds; ++i) {
+    rgb(&tt_leds[i], 255, 0, 0);
+  }
+  for (int i = num_of_leds; i < RING_LIGHT_LEDS; ++i) {
+    rgb(&tt_leds[i], 0, 0, 0);
+  }
+  timer_arm(&combo_tt_led_timer, CONFIG_CHANGE_NOTIFY_TIME);
+}
+
+#define DEADZONE_MAX 6
+#define DEADZONE_MIN 1
+void increase_deadzone(config* self) {
+  if (++self->tt_deadzone > DEADZONE_MAX) {
+    self->tt_deadzone = DEADZONE_MAX;
+  }
+  eeprom_update_byte(CONFIG_TT_DEADZONE_ADDR, self->tt_deadzone);
+
+  tt1.deadzone = self->tt_deadzone;
+
+  display_tt_change(self->tt_deadzone, DEADZONE_MAX);
+}
+
+void decrease_deadzone(config* self) {
+  if (--self->tt_deadzone < DEADZONE_MIN) {
+    self->tt_deadzone = DEADZONE_MIN;
+  }
+  eeprom_update_byte(CONFIG_TT_DEADZONE_ADDR, self->tt_deadzone);
+
+  tt1.deadzone = self->tt_deadzone;
+
+  display_tt_change(self->tt_deadzone, DEADZONE_MAX);
 }

--- a/fw/config.h
+++ b/fw/config.h
@@ -29,6 +29,8 @@
 #define RING_LIGHT_LEDS 24
 #define LIGHT_BAR_LEDS 16
 
+#define CONFIG_CHANGE_NOTIFY_TIME 1000
+
 // tentative names for LED ring modes
 typedef enum {
   RING_LIGHT_MODE_PLACEHOLDER1, // single colour
@@ -42,16 +44,23 @@ typedef enum {
   NUM_OF_RING_LIGHT_MODES
 } ring_light_mode;
 
+// Do not reorder these fields
 typedef struct {
   uint8_t version;
   uint8_t reverse_tt;
   ring_light_mode tt_effect;
+  uint8_t tt_deadzone;
 } config;
 
 void config_init(config* self);
 void toggle_reverse_tt(config* self);
 void cycle_tt_effects(config* self);
+void increase_deadzone(config* self);
+void decrease_deadzone(config* self);
 
 // button combos
+#define NUM_OF_COMBOS 4
 #define REVERSE_TT_COMBO (BUTTON_1 | BUTTON_7 | BUTTON_8)
 #define TT_EFFECTS_COMBO (BUTTON_2 | BUTTON_8 | BUTTON_11)
+#define TT_DEADZONE_INCR_COMBO (BUTTON_3 | BUTTON_8 | BUTTON_11)
+#define TT_DEADZONE_DECR_COMBO (BUTTON_1 | BUTTON_8 | BUTTON_11)

--- a/fw/rgb.h
+++ b/fw/rgb.h
@@ -6,9 +6,9 @@ typedef struct {
     uint8_t r;
     uint8_t g;
     uint8_t b;
-} rgb_lights;
+} rgb_light;
 
 typedef struct {
     uint16_t buttons;
-    rgb_lights tt_lights;
+    rgb_light tt_lights;
 } hid_lights;

--- a/fw/timer.c
+++ b/fw/timer.c
@@ -28,7 +28,12 @@ bool timer_is_expired(timer* self) {
 
   uint32_t now = milliseconds;
   int32_t diff = now - self->time_to_expire;
-  return (diff > 0);
+  return diff > 0;
+}
+
+bool timer_is_active(timer* self) {
+  return timer_is_armed(self) &&
+    !timer_check_if_expired_reset(self);
 }
 
 int32_t timer_get_remaining_time(timer* self) {

--- a/fw/timer.h
+++ b/fw/timer.h
@@ -14,5 +14,6 @@ void timer_arm(timer* self, uint32_t milliseconds_from_now);
 void timer_reset(timer* self);
 bool timer_is_armed(timer* self);
 bool timer_is_expired(timer* self);
+bool timer_is_active(timer* self);
 int32_t timer_get_remaining_time(timer* self);
 bool timer_check_if_expired_reset(timer* self);

--- a/fw/tt_rgb_manager.c
+++ b/fw/tt_rgb_manager.c
@@ -32,7 +32,7 @@ void react_to_scr(int8_t tt_report) {
     set_tt_leds_red();
     timer_arm(&led_timer, 500);
   } 
-  if (timer_check_if_expired_reset(&led_timer) || !timer_is_armed(&led_timer)) {
+  if (timer_check_if_expired_reset(&led_timer)) {
     set_tt_leds_off();
   }
 }

--- a/fw/tt_rgb_manager.c
+++ b/fw/tt_rgb_manager.c
@@ -32,7 +32,7 @@ void react_to_scr(int8_t tt_report) {
     set_tt_leds_red();
     timer_arm(&led_timer, 500);
   } 
-  if (timer_check_if_expired_reset(&led_timer)) {
+  if (!timer_is_active(&led_timer)) {
     set_tt_leds_off();
   }
 }

--- a/fw/tt_rgb_manager.c
+++ b/fw/tt_rgb_manager.c
@@ -6,45 +6,48 @@ void rgb(struct cRGB* led, uint8_t r, uint8_t g, uint8_t b) {
   led->b = b;
 }
 
-void set_tt_leds(rgb_lights lights) {
+void set_tt_leds(rgb_light lights) {
   for (int i = 0; i < RING_LIGHT_LEDS; ++i) {
-    rgb(&led[i], lights.r, lights.g, lights.b);
+    rgb(&tt_leds[i], lights.r, lights.g, lights.b);
   }
-  ws2812_setleds(led, RING_LIGHT_LEDS);
 }
 
-void set_led_blue(void) {
-  set_tt_leds((rgb_lights){0, 0, 255});
+void set_tt_leds_blue(void) {
+  set_tt_leds((rgb_light){0, 0, 255});
 }
 
-void set_led_red(void) {
-  set_tt_leds((rgb_lights){255, 0, 0});
+void set_tt_leds_red(void) {
+  set_tt_leds((rgb_light){255, 0, 0});
 }
 
-void set_led_off(void) {
-  set_tt_leds((rgb_lights){0});
+void set_tt_leds_off(void) {
+  set_tt_leds((rgb_light){0});
 }
 
 void react_to_scr(int8_t tt_report) {
   if (tt_report == 1) {
-    set_led_blue();
+    set_tt_leds_blue();
     timer_arm(&led_timer, 500);
   } else if (tt_report == -1) {
-    set_led_red();
+    set_tt_leds_red();
     timer_arm(&led_timer, 500);
   } 
   if (timer_check_if_expired_reset(&led_timer) || !timer_is_armed(&led_timer)) {
-    set_led_off();
+    set_tt_leds_off();
   }
 }
 
 void spin(void) {
   static uint8_t spin_counter = 0;
   if (timer_check_if_expired_reset(&spin_timer)) {
-    rgb(&(led[spin_counter]), 0, 0, 0);
     spin_counter = (spin_counter + 1) % RING_LIGHT_LEDS;
-    rgb(&(led[spin_counter]), 0, 0, 255);
-    ws2812_setleds(led, RING_LIGHT_LEDS);
+    for (int i = 0; i < RING_LIGHT_LEDS; i++) {
+      if (i == spin_counter) {
+        rgb(&(tt_leds[i]), 0, 0, 255);
+      } else {
+        rgb(&(tt_leds[i]), 0, 0, 0);
+      }
+    }
 
     timer_arm(&spin_timer, 50);
   }
@@ -52,19 +55,24 @@ void spin(void) {
 
 // tt +1 is counter-clockwise, -1 is clockwise
 void tt_rgb_manager_update(int8_t tt_report,
-                           rgb_lights lights,
+                           rgb_light lights,
                            ring_light_mode mode) {
-  switch(mode) {
-    case SPIN:
-      spin();
-      break;
-    case REACT_TO_SCR:
-      react_to_scr(tt_report);
-      break;
-    case HID:
-      set_tt_leds(lights);
-      break;
-    default:
-      break;
+  // Ignore turtable effect if notifying a mode change
+  if (!timer_is_active(&combo_tt_led_timer)) {
+      switch(mode) {
+      case SPIN:
+        spin();
+        break;
+      case REACT_TO_SCR:
+        react_to_scr(tt_report);
+        break;
+      case HID:
+        set_tt_leds(lights);
+        break;
+      default:
+        break;
+    }
   }
+
+  ws2812_setleds(tt_leds, RING_LIGHT_LEDS);
 }

--- a/fw/tt_rgb_manager.h
+++ b/fw/tt_rgb_manager.h
@@ -6,18 +6,19 @@
 #include "ws2812.h"
 
 timer led_timer;
-struct cRGB led[RING_LIGHT_LEDS];
+timer combo_tt_led_timer;
+struct cRGB tt_leds[RING_LIGHT_LEDS];
 timer spin_timer;
 
 void rgb(struct cRGB* led, uint8_t r, uint8_t g, uint8_t b);
-void set_tt_leds(rgb_lights lights);
-void set_led_blue(void);
-void set_led_red(void);
-void set_led_off(void);
+void set_tt_leds(rgb_light lights);
+void set_tt_leds_blue(void);
+void set_tt_leds_red(void);
+void set_tt_leds_off(void);
 
 void react_to_scr(int8_t tt_report);
 void spin(void);
 
 void tt_rgb_manager_update(int8_t tt_report,
-                           rgb_lights lights,
+                           rgb_light lights,
                            ring_light_mode mode);


### PR DESCRIPTION
* Implement deadzone adjustment
  * Button combo is B1 + B8 + B11 to decrease deadzone, B3 + B8 + B11 to increase deadzone
  * On deadzone change, light turntable red in proportion to the deadzone
    * Due to the light dispersion, it's a bit hard to distinguish what the current deadzone setting is. It's probably good enough for now though
  * Deadzone range is `[1..6]`
  * Default setting is 4
  * Not sure how this compares to the PWAN's settings, this can be improved upon later
* Implement turntable effect when changing `tt_reverse`
  * This sets the positive direction from the player's perspective blue, and the other direction red in two halves split horizontally
* Add new `timer` helper function `timer_is_active(..)` to check if a `timer` is running
* Increase config notify time to 1 second

I'm not sure what effects lower deadzone settings might have on older controllers, will need testing.