### PR TITLE
Declare structs in header files as extern to fix linking errors

### DIFF
--- a/fw/analog_turntable.h
+++ b/fw/analog_turntable.h
@@ -15,11 +15,11 @@ typedef struct {
   bool center_valid;
 
   // time to: reset center to counter
-  timer sustain_timer;  
+  timer sustain_timer;
 
   int8_t state; // -1, 0, 1
 } analog_turntable;
-analog_turntable tt1;
+extern analog_turntable tt1;
 
 void analog_turntable_init(analog_turntable* self, uint8_t deadzone, uint32_t sustain_ms, bool clear);
 int8_t analog_turntable_poll(analog_turntable* self, uint32_t current_value);

--- a/fw/beef.c
+++ b/fw/beef.c
@@ -7,6 +7,14 @@
 #include "beef.h"
 #include "tt_rgb_manager.h"
 
+// placing the following objects in global scope since extern
+// declarations expect them to be here
+timer led_timer;
+timer spin_timer;
+timer combo_tt_led_timer;
+analog_turntable tt1;
+struct cRGB tt_leds[RING_LIGHT_LEDS];
+
 // buffer to hold the previously generated HID report, for comparison purposes inside the HID class driver.
 static uint8_t PrevJoystickHIDReportBuffer[sizeof(USB_JoystickReport_Data_t)];
 
@@ -367,7 +375,7 @@ void update_lighting(int8_t tt1_report,
                            combo_lights_timer);
   }
 
-  tt_rgb_manager_update(tt1_report, 
+  tt_rgb_manager_update(tt1_report,
                         led_state_from_hid_report.tt_lights,
                         current_config.tt_effect);
 }

--- a/fw/pin.h
+++ b/fw/pin.h
@@ -27,7 +27,7 @@ typedef struct {
   uint16_t tt_position;
 } tt_pins;
 
-hw_pin hw_pins[6];
+extern hw_pin hw_pins[6];
 
 // to index into hw_pins[] array
 #define A_ 0

--- a/fw/timer.h
+++ b/fw/timer.h
@@ -3,7 +3,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-volatile uint32_t milliseconds;
+extern volatile uint32_t milliseconds;
 typedef struct {
   bool armed;
   uint32_t time_to_expire;

--- a/fw/tt_rgb_manager.c
+++ b/fw/tt_rgb_manager.c
@@ -31,7 +31,7 @@ void react_to_scr(int8_t tt_report) {
   } else if (tt_report == -1) {
     set_tt_leds_red();
     timer_arm(&led_timer, 500);
-  } 
+  }
   if (!timer_is_active(&led_timer)) {
     set_tt_leds_off();
   }

--- a/fw/tt_rgb_manager.h
+++ b/fw/tt_rgb_manager.h
@@ -5,10 +5,10 @@
 #include "timer.h"
 #include "ws2812.h"
 
-timer led_timer;
-timer combo_tt_led_timer;
-struct cRGB tt_leds[RING_LIGHT_LEDS];
-timer spin_timer;
+extern timer led_timer;
+extern timer combo_tt_led_timer;
+extern struct cRGB tt_leds[RING_LIGHT_LEDS];
+extern timer spin_timer;
 
 void rgb(struct cRGB* led, uint8_t r, uint8_t g, uint8_t b);
 void set_tt_leds(rgb_light lights);


### PR DESCRIPTION
Not quite sure why you two don't encounter this issue, but since these structs are indeed used by multiple translation units they must be declared `extern`. @ASleepyCat / @supervaka please confirm that this bulids for you guys.