### PR TITLE
Implement user adjustable static colour TT effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Various configuration options can be changed on-the-fly by holding a button comb
 | Disable LEDs | B4 + B8 + B11 |
 | Change turntable hue (static mode) | B2 + B11 + TT |
 | Change turntable saturation (static mode) | B4 + B11 + TT |
-| Change turntable vibrance (static mode) | B6 + B11 + TT |
+| Change turntable brightness (static mode) | B6 + B11 + TT |
 
 
 ## BOM

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Various configuration options can be changed on-the-fly by holding a button comb
 | Decrease TT deadzone | B1 + B8 + B11 |
 | Change centre bar lighting effects (PHOENIXWAN only) | B6 + B8 + B10 |
 | Disable LEDs | B4 + B8 + B11 |
+| Change turntable hue (static mode) | B2 + B11 + TT |
+| Change turntable saturation (static mode) | B4 + B11 + TT |
+| Change turntable vibrance (static mode) | B6 + B11 + TT |
 
 
 ## BOM

--- a/fw/analog_turntable.c
+++ b/fw/analog_turntable.c
@@ -29,6 +29,8 @@ int8_t analog_turntable_poll(analog_turntable* self, uint32_t current_value) {
     direction = -1;
   }
 
+  self->raw_state = direction;
+
   if (direction != 0) {
     // turntable is moving
     // keep updating the new center, and keep extending the sustain timer

--- a/fw/analog_turntable.h
+++ b/fw/analog_turntable.h
@@ -21,6 +21,7 @@ typedef struct {
   timer sustain_timer;
 
   int8_t state; // -1, 0, 1
+  int8_t raw_state; // state without sustain period
 } analog_turntable;
 extern analog_turntable tt1;
 

--- a/fw/beef.cpp
+++ b/fw/beef.cpp
@@ -1,5 +1,6 @@
 #include "analog_turntable.h"
 #include "beef.h"
+#include "combo.h"
 #include "fastled_shim.h"
 #include "rgb_manager.h"
 
@@ -45,58 +46,6 @@ tt_pins tt_x = { &PINF, 0, 1, -1, 0 };
 // tt_pins tt_y = { &PIN?, ?, ?, -1, 0 };
 
 config current_config;
-
-struct combo {
-  uint16_t button_combo;
-  bool continuous;
-  void (*config_set)(config*);
-  void (*config_update)(config*);
-};
-
-combo button_combos[NUM_OF_COMBOS] = {
-  {
-    button_combo: REVERSE_TT_COMBO,
-    config_set: toggle_reverse_tt
-  },
-  {
-    button_combo: TT_EFFECTS_COMBO,
-    config_set: cycle_tt_effects
-  },
-  {
-    button_combo: TT_DEADZONE_INCR_COMBO,
-    config_set: increase_deadzone
-  },
-  {
-    button_combo: TT_DEADZONE_DECR_COMBO,
-    config_set: decrease_deadzone
-  },
-  {
-    button_combo: BAR_EFFECTS_COMBO,
-    config_set: cycle_bar_effects
-  },
-  {
-    button_combo: DISABLE_LED_COMBO,
-    config_set: toggle_disable_led
-  },
-  {
-    button_combo: TT_HSV_HUE_COMBO,
-    continuous: true,
-    config_set: tt_hsv_set_hue,
-    config_update: tt_hsv_update_hue
-  },
-  {
-    button_combo: TT_HSV_SAT_COMBO,
-    continuous: true,
-    config_set: tt_hsv_set_sat,
-    config_update: tt_hsv_update_sat
-  },
-  {
-    button_combo: TT_HSV_VAL_COMBO,
-    continuous: true,
-    config_set: tt_hsv_set_val,
-    config_update: tt_hsv_update_val
-  },
-};
 
 ISR(TIMER1_COMPA_vect) {
   milliseconds++;
@@ -299,53 +248,6 @@ void process_button(volatile uint8_t* PIN,
     button_state |= (1 << button_number);
   } else {
     button_state &= ~(1 << button_number);
-  }
-}
-
-void process_combos(config* current_config,
-                    timer* combo_timer,
-                    timer* combo_lights_timer) {
-  static bool ignore_combo = false;
-  static combo last_combo;
-  bool combo_pressed = false;
-
-  for (uint8_t i = 0; i < NUM_OF_COMBOS; ++i) {
-    auto button_combo = button_combos[i];
-    if (is_pressed_strict(button_combo.button_combo)) {
-      last_combo = button_combo;
-      combo_pressed = true;
-      if (ignore_combo) {
-        return;
-      }
-
-      if (button_combo.continuous) {
-        button_combo.config_set(current_config);
-      } else {
-        // arm timer if not already armed
-        if (!timer_is_armed(combo_timer)) {
-          timer_arm(combo_timer, 1000);
-        }
-
-        if (timer_check_if_expired_reset(combo_timer)) {
-          button_combo.config_set(current_config);
-          timer_arm(combo_lights_timer, CONFIG_CHANGE_NOTIFY_TIME);
-          ignore_combo = true;
-        }
-      }
-
-      return;
-    }
-  }
-
-  if (!combo_pressed) {
-    ignore_combo = false;
-    timer_init(combo_timer);
-    timer_init(combo_lights_timer);
-    timer_init(&RgbManager::Turntable::combo_timer);
-
-    if (last_combo.continuous) {
-      last_combo.config_update(current_config);
-    }
   }
 }
 

--- a/fw/beef.h
+++ b/fw/beef.h
@@ -33,9 +33,6 @@ void set_hid_standby_lighting(hid_lights* lights);
 void process_button(volatile uint8_t* PIN,
                     uint8_t button_number,
                     uint8_t input_pin);
-void process_combos(config* current_config,
-                    timer* combo_timer,
-                    timer* combo_lights_timer);
 void process_tt(volatile uint8_t* PIN,
                 uint8_t a_pin,
                 uint8_t b_pin,

--- a/fw/combo.cpp
+++ b/fw/combo.cpp
@@ -1,0 +1,101 @@
+#include "beef.h"
+#include "combo.h"
+
+struct combo {
+  uint16_t button_combo;
+  bool continuous;
+  void (*config_set)(config*);
+  void (*config_update)(config*);
+};
+
+combo button_combos[NUM_OF_COMBOS] = {
+  {
+    button_combo: REVERSE_TT_COMBO,
+    config_set: toggle_reverse_tt
+  },
+  {
+    button_combo: TT_EFFECTS_COMBO,
+    config_set: cycle_tt_effects
+  },
+  {
+    button_combo: TT_DEADZONE_INCR_COMBO,
+    config_set: increase_deadzone
+  },
+  {
+    button_combo: TT_DEADZONE_DECR_COMBO,
+    config_set: decrease_deadzone
+  },
+  {
+    button_combo: BAR_EFFECTS_COMBO,
+    config_set: cycle_bar_effects
+  },
+  {
+    button_combo: DISABLE_LED_COMBO,
+    config_set: toggle_disable_led
+  },
+  {
+    button_combo: TT_HSV_HUE_COMBO,
+    continuous: true,
+    config_set: tt_hsv_set_hue,
+    config_update: tt_hsv_update_hue
+  },
+  {
+    button_combo: TT_HSV_SAT_COMBO,
+    continuous: true,
+    config_set: tt_hsv_set_sat,
+    config_update: tt_hsv_update_sat
+  },
+  {
+    button_combo: TT_HSV_VAL_COMBO,
+    continuous: true,
+    config_set: tt_hsv_set_val,
+    config_update: tt_hsv_update_val
+  },
+};
+
+void process_combos(config* current_config,
+                    timer* combo_timer,
+                    timer* combo_lights_timer) {
+  static bool ignore_combo = false;
+  static combo last_combo;
+  bool combo_pressed = false;
+
+  for (uint8_t i = 0; i < NUM_OF_COMBOS; ++i) {
+    auto button_combo = button_combos[i];
+    if (is_pressed_strict(button_combo.button_combo)) {
+      last_combo = button_combo;
+      combo_pressed = true;
+      if (ignore_combo) {
+        return;
+      }
+
+      if (button_combo.continuous) {
+        button_combo.config_set(current_config);
+      } else {
+        // arm timer if not already armed
+        if (!timer_is_armed(combo_timer)) {
+          timer_arm(combo_timer, 1000);
+        }
+
+        if (timer_check_if_expired_reset(combo_timer)) {
+          button_combo.config_set(current_config);
+          timer_arm(combo_lights_timer, CONFIG_CHANGE_NOTIFY_TIME);
+          ignore_combo = true;
+        }
+      }
+
+      return;
+    }
+  }
+
+  if (!combo_pressed) {
+    ignore_combo = false;
+    timer_init(combo_timer);
+    timer_init(combo_lights_timer);
+    timer_init(&RgbManager::Turntable::combo_timer);
+
+    if (last_combo.continuous) {
+      last_combo.config_update(current_config);
+    }
+  }
+}

--- a/fw/combo.h
+++ b/fw/combo.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "config.h"
+
+void process_combos(config* current_config,
+                    timer* combo_timer,
+                    timer* combo_lights_timer);

--- a/fw/config.cpp
+++ b/fw/config.cpp
@@ -20,7 +20,7 @@
 #include "analog_turntable.h"
 #include "config.h"
 
-const auto default_colour = rgb2hsv_approximate(CRGB::Turquoise);
+const auto default_colour = HSV{ 124, 182, 225 }; // Turquoise (approx.)
 
 // initialize config with default values
 void init_config(config* self) {
@@ -30,7 +30,7 @@ void init_config(config* self) {
   self->tt_deadzone = 4;
   self->bar_effect = RgbManager::Bar::Mode::HID;
   self->disable_led = 0;
-  self->tt_hsv = HSV{ default_colour.h, 255, 255 };
+  self->tt_hsv = default_colour;
 }
 
 bool update_config(config* self) {
@@ -54,7 +54,7 @@ bool update_config(config* self) {
     self->version++;
     update = true;
   case 4:
-    self->tt_hsv = HSV{ default_colour.h, 255, 255 };
+    self->tt_hsv = default_colour;
     self->version++;
     update = true;
   }

--- a/fw/config.cpp
+++ b/fw/config.cpp
@@ -20,7 +20,7 @@
 #include "analog_turntable.h"
 #include "config.h"
 
-const auto default_colour = HSV{ 124, 182, 225 }; // Turquoise (approx.)
+const auto default_colour = HSV{ 127, 255, 255 }; // Aqua
 
 // initialize config with default values
 void init_config(config* self) {

--- a/fw/config.h
+++ b/fw/config.h
@@ -39,21 +39,31 @@ typedef struct {
   uint8_t tt_deadzone;
   RgbManager::Bar::Mode bar_effect;
   uint8_t disable_led;
+  HSV tt_hsv;
 } config;
 
 void config_init(config* self);
 void toggle_reverse_tt(config* self);
 void cycle_tt_effects(config* self);
+void tt_hsv_set_hue(config* self);
+void tt_hsv_update_hue(config* self);
+void tt_hsv_set_sat(config* self);
+void tt_hsv_update_sat(config* self);
+void tt_hsv_set_val(config* self);
+void tt_hsv_update_val(config* sel);
 void increase_deadzone(config* self);
 void decrease_deadzone(config* self);
 void cycle_bar_effects(config* self);
 void toggle_disable_led(config* self);
 
 // button combos
-#define NUM_OF_COMBOS 6
+#define NUM_OF_COMBOS 9
 #define REVERSE_TT_COMBO (BUTTON_1 | BUTTON_7 | BUTTON_8)
 #define TT_EFFECTS_COMBO (BUTTON_2 | BUTTON_8 | BUTTON_11)
 #define TT_DEADZONE_INCR_COMBO (BUTTON_3 | BUTTON_8 | BUTTON_11)
 #define TT_DEADZONE_DECR_COMBO (BUTTON_1 | BUTTON_8 | BUTTON_11)
 #define BAR_EFFECTS_COMBO (BUTTON_6 | BUTTON_8 | BUTTON_10)
 #define DISABLE_LED_COMBO (BUTTON_4 | BUTTON_8 | BUTTON_11)
+#define TT_HSV_HUE_COMBO (BUTTON_2 | BUTTON_11)
+#define TT_HSV_SAT_COMBO (BUTTON_4 | BUTTON_11)
+#define TT_HSV_VAL_COMBO (BUTTON_6 | BUTTON_11)

--- a/fw/makefile
+++ b/fw/makefile
@@ -9,7 +9,7 @@ BEEF_LED_REFRESH ?= 40
 BEEF_TT_RATIO ?= 2
 FASTLED_SRC = FastLED/src
 SRC = $(wildcard *.c) $(wildcard *.cpp) \
-	$(FASTLED_SRC)/colorutils.cpp $(FASTLED_SRC)/FastLED.cpp $(FASTLED_SRC)/lib8tion.cpp \
+	$(FASTLED_SRC)/colorutils.cpp $(FASTLED_SRC)/FastLED.cpp $(FASTLED_SRC)/hsv2rgb.cpp $(FASTLED_SRC)/lib8tion.cpp \
 	$(LUFA_SRC_USB) $(LUFA_SRC_USBCLASS)
 LUFA_PATH = LUFA
 CC_FLAGS = -DUSE_LUFA_CONFIG_HEADER -IConfig/ -include fastled_shim.h \

--- a/fw/rgb.h
+++ b/fw/rgb.h
@@ -3,13 +3,15 @@
 #include <stdint.h>
 
 typedef struct {
-    uint8_t r;
-    uint8_t g;
-    uint8_t b;
+  uint8_t r, g, b;
 } rgb_light;
 
+struct HSV {
+  uint8_t h, s, v;
+};
+
 typedef struct {
-    uint16_t buttons;
-    rgb_light tt_lights;
-    rgb_light bar_lights;
+  uint16_t buttons;
+  rgb_light tt_lights;
+  rgb_light bar_lights;
 } hid_lights;

--- a/fw/rgb_manager.cpp
+++ b/fw/rgb_manager.cpp
@@ -25,9 +25,14 @@ namespace RgbManager {
       } 
     }
 
-    void set_leds(rgb_light lights) {
+    void set_rgb(rgb_light lights) {
       fill_solid(leds, RING_LIGHT_LEDS,
                  CRGB(lights.r, lights.g, lights.b));
+    }
+
+    void set_hsv(HSV hsv) {
+      fill_solid(leds, RING_LIGHT_LEDS,
+                 CHSV(hsv.h, hsv.s, hsv.v));
     }
 
     void set_leds_blue(void) {
@@ -94,20 +99,24 @@ namespace RgbManager {
     // tt +1 is counter-clockwise, -1 is clockwise
     void update(int8_t tt_report,
                 rgb_light lights,
+                HSV hsv,
                 Mode mode) {
       // Ignore turtable effect if notifying a mode change
       if (!timer_is_active(&combo_timer)) {
         switch(mode) {
-          case SPIN:
+          case Mode::STATIC:
+            set_hsv(hsv);
+            break;
+          case Mode::SPIN:
             spin();
             break;
-          case REACT_TO_SCR:
+          case Mode::REACT_TO_SCR:
             react_to_scr(tt_report);
             break;
-          case HID:
-            set_leds(lights);
+          case Mode::HID:
+            set_rgb(lights);
             break;
-          case DISABLE:
+          case Mode::DISABLE:
             set_leds_off();
             break;
           default:
@@ -142,10 +151,10 @@ namespace RgbManager {
     void update(rgb_light lights,
                 Mode mode) {
       switch(mode) {
-        case HID:
+        case Mode::HID:
           set_leds(lights);
           break;
-        case DISABLE:
+        case Mode::DISABLE:
           set_leds_off();
           break;
         default:

--- a/fw/rgb_manager.cpp
+++ b/fw/rgb_manager.cpp
@@ -31,8 +31,9 @@ namespace RgbManager {
     }
 
     void set_hsv(HSV hsv) {
-      fill_solid(leds, RING_LIGHT_LEDS,
-                 CHSV(hsv.h, hsv.s, hsv.v));
+      CRGB rgb;
+      hsv2rgb_spectrum(CHSV{hsv.h, hsv.s, hsv.v}, rgb);
+      fill_solid(leds, RING_LIGHT_LEDS, rgb);
     }
 
     void set_leds_blue(void) {
@@ -53,8 +54,8 @@ namespace RgbManager {
       EVERY_N_MILLIS(SPIN_TIMER) {
         spin_counter = (spin_counter + 1) % (RING_LIGHT_LEDS / 2);
         set_leds_off();
-        leds[spin_counter] = CRGB::Turquoise;
-        leds[spin_counter+12] = CRGB::Turquoise;
+        leds[spin_counter] = CRGB::Aqua;
+        leds[spin_counter+12] = CRGB::Aqua;
       }
     }
 

--- a/fw/rgb_manager.h
+++ b/fw/rgb_manager.h
@@ -15,7 +15,7 @@ namespace RgbManager {
 
     // tentative names for LED ring modes
     enum class Mode : uint8_t {
-      STATIC, // single colour
+      STATIC,
       SPIN,
       PLACEHOLDER2, // colour shift
       PLACEHOLDER3, // static rainbow

--- a/fw/rgb_manager.h
+++ b/fw/rgb_manager.h
@@ -14,8 +14,8 @@ namespace RgbManager {
     extern CRGB leds[RING_LIGHT_LEDS];
 
     // tentative names for LED ring modes
-    enum Mode {
-      PLACEHOLDER1, // single colour
+    enum class Mode : uint8_t {
+      STATIC, // single colour
       SPIN,
       PLACEHOLDER2, // colour shift
       PLACEHOLDER3, // static rainbow
@@ -26,22 +26,23 @@ namespace RgbManager {
       DISABLE,
       COUNT
     };
-    static_assert(sizeof(Mode) == sizeof(uint8_t));
 
     void init();
-    void set_leds(rgb_light lights);
+    void set_rgb(rgb_light lights);
+    void set_hsv(HSV hsv);
     void set_leds_off(void);
     void reverse_tt(uint8_t reverse_tt);
     void display_tt_change(uint8_t deadzone, int range);
     void update(int8_t tt_report,
                 rgb_light lights,
+                HSV hsv,
                 Mode mode);
   }
 
   namespace Bar {
     extern CRGB leds[LIGHT_BAR_LEDS];
 
-    enum Mode {
+    enum class Mode : uint8_t {
       PLACEHOLDER1, // beat
       PLACEHOLDER2, // reactive p1
       PLACEHOLDER3, // audio spectrum
@@ -50,7 +51,6 @@ namespace RgbManager {
       DISABLE,
       COUNT
     };
-    static_assert(sizeof(Mode) == sizeof(uint8_t));
 
     void init();
     void set_leds(rgb_light lights);


### PR DESCRIPTION
Closes #43.

* Default colour is aqua
  * Looking at tokaku's review it seems like this is the default setting
  * Also changed the spin effect colour to aqua as well
  * Still too lazy to rewire my stock board and take some reference pictures
* Button combos are:
  * `B2 + B11 + TT` to adjust hue
  * `B4 + B11 + TT` to adjust saturation
  * `B6 + B11 + TT` to adjust value
* Add continuous-held button combos
  * These will be immediately active whenever the button combo is pressed, and the setting is only written to EEPROM when the combo is released
* Add `raw_state` to `analog_turntable`
  * Tracks what the current TT input is without the sustain period kicking in
  * `state` causes the HSV adjustments to go crazy, probably due to the sustain period?