### PR TITLE
Force enable reactive LEDs during HID mode when button combo is pressed

### DIFF
--- a/fw/beef.h
+++ b/fw/beef.h
@@ -23,6 +23,8 @@ typedef struct {
   uint16_t Button; // bit-field representing which buttons have been pressed
 } USB_JoystickReport_Data_t;
 
+extern bool reactive_led;
+
 void hwinit(void);
 void hardware_timer1_init(void);
 void set_led(volatile uint8_t* PORT,
@@ -44,7 +46,7 @@ void update_lighting(int8_t tt1_report,
                      config current_config);
 void update_button_lighting(uint16_t led_state,
                             timer* combo_lights_timer,
-			    config current_config);
+                            config current_config);
 bool is_pressed(uint16_t button_bits);
 bool is_pressed_strict(uint16_t button_bits);
 

--- a/fw/combo.cpp
+++ b/fw/combo.cpp
@@ -70,9 +70,7 @@ void process_combos(config* current_config,
         combo_activated = true;
         in_hid = !reactive_led;
       }
-      if (in_hid) {
-        reactive_led = true; 
-      }
+      reactive_led = true;
 
       if (ignore_combo) {
         return;

--- a/fw/combo.cpp
+++ b/fw/combo.cpp
@@ -56,15 +56,24 @@ combo button_combos[NUM_OF_COMBOS] = {
 void process_combos(config* current_config,
                     timer* combo_timer,
                     timer* combo_lights_timer) {
+  static bool combo_activated = false;
   static bool ignore_combo = false;
+  static bool in_hid = false;
   static combo last_combo;
-  bool combo_pressed = false;
 
   for (uint8_t i = 0; i < NUM_OF_COMBOS; ++i) {
     auto button_combo = button_combos[i];
     if (is_pressed_strict(button_combo.button_combo)) {
       last_combo = button_combo;
-      combo_pressed = true;
+
+      if (!combo_activated) {
+        combo_activated = true;
+        in_hid = !reactive_led;
+      }
+      if (in_hid) {
+        reactive_led = true; 
+      }
+
       if (ignore_combo) {
         return;
       }
@@ -88,8 +97,13 @@ void process_combos(config* current_config,
     }
   }
 
-  if (!combo_pressed) {
+  if (combo_activated) {
+    combo_activated = false;
     ignore_combo = false;
+    if (in_hid) {
+      reactive_led = false;
+    }
+
     timer_init(combo_timer);
     timer_init(combo_lights_timer);
     timer_init(&RgbManager::Turntable::combo_timer);


### PR DESCRIPTION
Closes #46.

Also removes unnecessary button combo resets by only resetting timers and saving config once when no combo is pressed.