### PR TITLE
Implement HSV adjustments for TT light modes

### DIFF
--- a/fw/beef.cpp
+++ b/fw/beef.cpp
@@ -74,8 +74,7 @@ int main() {
 
   analog_turntable_init(&tt1, current_config.tt_deadzone, 200, true);
 
-  RgbManager::Turntable::init();
-  RgbManager::Bar::init();
+  RgbManager::init();
 
   // tt_x DATA lines wired to F0/F1
   DDRF  &= 0b11111100;
@@ -257,7 +256,7 @@ void process_button(const volatile uint8_t* PIN,
   button_state |= pressed << button_number;
 }
 
-void process_tt(tt_pins& tt_pin) {
+void process_tt(tt_pins &tt_pin) {
   // tt logic
   // example where tt_x wired to F0/F1:
   // curr is binary number ab
@@ -308,10 +307,9 @@ void update_lighting(int8_t tt1_report,
 
     RgbManager::Turntable::update(tt1_report,
                                   led_state_from_hid_report.tt_lights,
-                                  current_config.tt_hsv,
-                                  current_config.tt_effect);
+                                  current_config);
     RgbManager::Bar::update(led_state_from_hid_report.bar_lights,
-                            current_config.bar_effect);
+                            current_config);
 
     FastLED.show();
   }

--- a/fw/beef.h
+++ b/fw/beef.h
@@ -34,7 +34,7 @@ void process_buttons(int8_t tt1_report);
 void process_button(const volatile uint8_t* PIN,
                     uint8_t button_number,
                     uint8_t input_pin);
-void process_tt(tt_pins& tt_pin);
+void process_tt(tt_pins &tt_pin);
 void update_lighting(int8_t tt1_report,
                      timer* combo_lights_timer);
 void update_button_lighting(uint16_t led_state,

--- a/fw/config.cpp
+++ b/fw/config.cpp
@@ -12,6 +12,12 @@
 #define CONFIG_TT_SPIN_HUE_ADDR (CONFIG_BASE_ADDR + offsetof(config, tt_spin_hsv.h))
 #define CONFIG_TT_SHIFT_SAT_ADDR (CONFIG_BASE_ADDR + offsetof(config, tt_shift_hsv.s))
 #define CONFIG_TT_SHIFT_VAL_ADDR (CONFIG_BASE_ADDR + offsetof(config, tt_shift_hsv.v))
+#define CONFIG_TT_RAINBOW_STATIC_SAT_ADDR (CONFIG_BASE_ADDR + offsetof(config, tt_rainbow_static_hsv.s))
+#define CONFIG_TT_RAINBOW_STATIC_VAL_ADDR (CONFIG_BASE_ADDR + offsetof(config, tt_rainbow_static_hsv.v))
+#define CONFIG_TT_RAINBOW_REACT_SAT_ADDR (CONFIG_BASE_ADDR + offsetof(config, tt_rainbow_react_hsv.s))
+#define CONFIG_TT_RAINBOW_REACT_VAL_ADDR (CONFIG_BASE_ADDR + offsetof(config, tt_rainbow_react_hsv.v))
+#define CONFIG_TT_RAINBOW_SPIN_SAT_ADDR (CONFIG_BASE_ADDR + offsetof(config, tt_rainbow_spin_hsv.s))
+#define CONFIG_TT_RAINBOW_SPIN_VAL_ADDR (CONFIG_BASE_ADDR + offsetof(config, tt_rainbow_spin_hsv.v))
 #define CONFIG_TT_REACT_HUE_ADDR (CONFIG_BASE_ADDR + offsetof(config, tt_react_hsv.h))
 #define CONFIG_TT_REACT_SAT_ADDR (CONFIG_BASE_ADDR + offsetof(config, tt_react_hsv.s))
 #define CONFIG_TT_BREATHING_HUE_ADDR (CONFIG_BASE_ADDR + offsetof(config, tt_breathing_hsv.h))
@@ -38,6 +44,9 @@ void init_config(config* self) {
   self->tt_static_hsv = DEFAULT_COLOUR;
   self->tt_spin_hsv = DEFAULT_COLOUR;
   self->tt_shift_hsv = { 0, 255, 255 };
+  self->tt_rainbow_react_hsv = { 0, 255, 255 };
+  self->tt_rainbow_react_hsv = { 0, 255, 255 };
+  self->tt_rainbow_spin_hsv = { 0, 255, 255 };
   self->tt_react_hsv = DEFAULT_COLOUR;
   self->tt_breathing_hsv = DEFAULT_COLOUR;
 }
@@ -68,6 +77,9 @@ bool update_config(config* self) {
     case 6:
       self->tt_spin_hsv = DEFAULT_COLOUR;
       self->tt_shift_hsv = { 0, 255, 255 };
+      self->tt_rainbow_react_hsv = { 0, 255, 255 };
+      self->tt_rainbow_react_hsv = { 0, 255, 255 };
+      self->tt_rainbow_spin_hsv = { 0, 255, 255 };
       self->tt_react_hsv = DEFAULT_COLOUR;
       self->tt_breathing_hsv = DEFAULT_COLOUR;
       self->version++;
@@ -162,6 +174,18 @@ callback tt_hsv_set_sat(config* self) {
       addr = CONFIG_TT_SHIFT_SAT_ADDR;
       s = &self->tt_shift_hsv;
       break;
+    case TurntableMode::RAINBOW_STATIC:
+      addr = CONFIG_TT_RAINBOW_STATIC_SAT_ADDR;
+      s = &self->tt_rainbow_static_hsv;
+      break;
+    case TurntableMode::RAINBOW_REACT:
+      addr = CONFIG_TT_RAINBOW_REACT_SAT_ADDR;
+      s = &self->tt_rainbow_react_hsv;
+      break;
+    case TurntableMode::RAINBOW_SPIN:
+      addr = CONFIG_TT_RAINBOW_SPIN_SAT_ADDR;
+      s = &self->tt_rainbow_spin_hsv;
+      break;
     case TurntableMode::REACT:
       addr = CONFIG_TT_REACT_SAT_ADDR;
       s = &self->tt_react_hsv;
@@ -197,6 +221,18 @@ callback tt_hsv_set_val(config* self) {
     case TurntableMode::SHIFT:
       addr = CONFIG_TT_SHIFT_VAL_ADDR;
       v = &self->tt_shift_hsv;
+      break;
+    case TurntableMode::RAINBOW_STATIC:
+      addr = CONFIG_TT_RAINBOW_STATIC_SAT_ADDR;
+      v = &self->tt_rainbow_static_hsv;
+      break;
+    case TurntableMode::RAINBOW_REACT:
+      addr = CONFIG_TT_RAINBOW_REACT_SAT_ADDR;
+      v = &self->tt_rainbow_react_hsv;
+      break;
+    case TurntableMode::RAINBOW_SPIN:
+      addr = CONFIG_TT_RAINBOW_SPIN_SAT_ADDR;
+      v = &self->tt_rainbow_spin_hsv;
       break;
     default:
       return callback{};

--- a/fw/config.cpp
+++ b/fw/config.cpp
@@ -1,58 +1,79 @@
-#define CONFIG_VERSION 6
-
+#pragma region Addresses
 #define CONFIG_BASE_ADDR (uint8_t*)2
-#define CONFIG_VERSION_ADDR CONFIG_BASE_ADDR
-#define CONFIG_REVERSE_TT_ADDR (CONFIG_VERSION_ADDR + sizeof(config::version))
-#define CONFIG_TT_EFFECT_ADDR (CONFIG_REVERSE_TT_ADDR + sizeof(config::reverse_tt))
-#define CONFIG_TT_DEADZONE_ADDR (CONFIG_TT_EFFECT_ADDR + sizeof(config::tt_effect))
-#define CONFIG_BAR_EFFECT_ADDR (CONFIG_TT_DEADZONE_ADDR + sizeof(config::tt_deadzone))
-#define CONFIG_DISABLE_LED_ADDR (CONFIG_BAR_EFFECT_ADDR + sizeof(config::bar_effect))
-#define CONFIG_TT_HSV_HUE_ADDR (CONFIG_DISABLE_LED_ADDR + sizeof(config::disable_led))
-#define CONFIG_TT_HSV_SAT_ADDR (CONFIG_TT_HSV_HUE_ADDR + sizeof(config::tt_hsv.h))
-#define CONFIG_TT_HSV_VAL_ADDR (CONFIG_TT_HSV_SAT_ADDR + sizeof(config::tt_hsv.s))
+#define CONFIG_VERSION_ADDR (CONFIG_BASE_ADDR + offsetof(config, version))
+#define CONFIG_REVERSE_TT_ADDR (CONFIG_BASE_ADDR + offsetof(config, reverse_tt))
+#define CONFIG_TT_EFFECT_ADDR (CONFIG_BASE_ADDR + offsetof(config, tt_effect))
+#define CONFIG_TT_DEADZONE_ADDR (CONFIG_BASE_ADDR + offsetof(config, tt_deadzone))
+#define CONFIG_BAR_EFFECT_ADDR (CONFIG_BASE_ADDR + offsetof(config, bar_effect))
+#define CONFIG_DISABLE_LED_ADDR (CONFIG_BASE_ADDR + offsetof(config, disable_led))
+#define CONFIG_TT_STATIC_HUE_ADDR (CONFIG_BASE_ADDR + offsetof(config, tt_static_hsv.h))
+#define CONFIG_TT_STATIC_SAT_ADDR (CONFIG_BASE_ADDR + offsetof(config, tt_static_hsv.s))
+#define CONFIG_TT_STATIC_VAL_ADDR (CONFIG_BASE_ADDR + offsetof(config, tt_static_hsv.v))
+#define CONFIG_TT_SPIN_HUE_ADDR (CONFIG_BASE_ADDR + offsetof(config, tt_spin_hsv.h))
+#define CONFIG_TT_SHIFT_SAT_ADDR (CONFIG_BASE_ADDR + offsetof(config, tt_shift_hsv.s))
+#define CONFIG_TT_SHIFT_VAL_ADDR (CONFIG_BASE_ADDR + offsetof(config, tt_shift_hsv.v))
+#define CONFIG_TT_REACT_HUE_ADDR (CONFIG_BASE_ADDR + offsetof(config, tt_react_hsv.h))
+#define CONFIG_TT_REACT_SAT_ADDR (CONFIG_BASE_ADDR + offsetof(config, tt_react_hsv.s))
+#define CONFIG_TT_BREATHING_HUE_ADDR (CONFIG_BASE_ADDR + offsetof(config, tt_breathing_hsv.h))
+#define CONFIG_TT_BREATHING_SAT_ADDR (CONFIG_BASE_ADDR + offsetof(config, tt_breathing_hsv.s))
+#pragma endregion Addresses
 
+#define CONFIG_VERSION 7
 #define MAGIC 0xBEEF
 
 #include <avr/eeprom.h>
 
 #include "analog_turntable.h"
 #include "config.h"
+#include "rgb_manager.h"
 
 // initialize config with default values
 void init_config(config* self) {
   self->version = CONFIG_VERSION;
   self->reverse_tt = 0;
-  self->tt_effect = RgbManager::Turntable::Mode::SPIN;
+  self->tt_effect = TurntableMode::SPIN;
   self->tt_deadzone = 4;
-  self->bar_effect = RgbManager::Bar::Mode::HID;
+  self->bar_effect = BarMode::HID;
   self->disable_led = 0;
-  self->tt_hsv = default_colour;
+  self->tt_static_hsv = DEFAULT_COLOUR;
+  self->tt_spin_hsv = DEFAULT_COLOUR;
+  self->tt_shift_hsv = { 0, 255, 255 };
+  self->tt_react_hsv = DEFAULT_COLOUR;
+  self->tt_breathing_hsv = DEFAULT_COLOUR;
 }
 
 bool update_config(config* self) {
   bool update = false;
 
   switch (self->version) {
-  case 0:
-    self->tt_effect = RgbManager::Turntable::Mode::SPIN;
-    self->version++;
-  case 1:
-    self->tt_deadzone = 4;
-    self->version++;
-  case 2:
-    self->bar_effect = RgbManager::Bar::Mode::HID;
-    self->version++;
-  case 3:
-    self->disable_led = 0;
-    self->version++;
-  case 4:
-    self->tt_hsv = default_colour;
-    self->version++;
-  case 5:
-    if (self->tt_effect >= RgbManager::Turntable::Mode::RAINBOW_SPIN) // Added new effect
-      self->tt_effect = RgbManager::Turntable::Mode(uint8_t(self->tt_effect)+1);
-    self->version++;
-    update = true;
+    case 0:
+      self->tt_effect = TurntableMode::SPIN;
+      self->version++;
+    case 1:
+      self->tt_deadzone = 4;
+      self->version++;
+    case 2:
+      self->bar_effect = BarMode::HID;
+      self->version++;
+    case 3:
+      self->disable_led = 0;
+      self->version++;
+    case 4:
+      self->tt_static_hsv = DEFAULT_COLOUR;
+      self->version++;
+    case 5:
+      if (self->tt_effect >= TurntableMode::RAINBOW_SPIN) // Added new effect
+        self->tt_effect = TurntableMode(uint8_t(self->tt_effect)+1);
+      self->version++;
+    case 6:
+      self->tt_spin_hsv = DEFAULT_COLOUR;
+      self->tt_shift_hsv = { 0, 255, 255 };
+      self->tt_react_hsv = DEFAULT_COLOUR;
+      self->tt_breathing_hsv = DEFAULT_COLOUR;
+      self->version++;
+      update = true;
+    default:
+      break;
   }
 
   return update;
@@ -62,7 +83,7 @@ void config_init(config* self) {
   eeprom_read_block(self, CONFIG_BASE_ADDR, sizeof(*self));
 
   bool update;
-  uint16_t magic = eeprom_read_word(nullptr);
+  const uint16_t magic = eeprom_read_word(nullptr);
   if (magic != MAGIC) {
     update = true;
     eeprom_write_word(nullptr, MAGIC);
@@ -71,80 +92,136 @@ void config_init(config* self) {
     update = update_config(self);
   }
 
-  if (update) {
+  if (update)
     eeprom_write_block(self, CONFIG_BASE_ADDR, sizeof(*self));
-  }
 }
 
-void toggle_reverse_tt(config* self) {
+void config_update(uint8_t* addr, const uint8_t val) {
+  eeprom_update_byte(addr, val);
+}
+
+callback toggle_reverse_tt(config* self) {
   self->reverse_tt ^= 1;
   eeprom_write_byte(CONFIG_REVERSE_TT_ADDR, self->reverse_tt);
 
   RgbManager::Turntable::reverse_tt(self->reverse_tt);
   timer_arm(&RgbManager::Turntable::combo_timer, CONFIG_CHANGE_NOTIFY_TIME);
+
+  return callback{};
 }
 
-void cycle_tt_effects(config* self) {
-  using namespace RgbManager::Turntable;
-  self->tt_effect = Mode((uint8_t(self->tt_effect) + 1) % uint8_t(Mode::COUNT));
+callback cycle_tt_effects(config* self) {
+  self->tt_effect = TurntableMode((uint8_t(self->tt_effect) + 1) % uint8_t(TurntableMode::COUNT));
   eeprom_write_byte(CONFIG_TT_EFFECT_ADDR, uint8_t(self->tt_effect));
 
-  set_leds_off();
+  RgbManager::Turntable::set_leds_off();
+
+  return callback{};
 }
 
-void tt_hsv_set_hue(config* self) {
-  if (self->tt_effect != RgbManager::Turntable::Mode::STATIC)
-    return;
+callback tt_hsv_set_hue(config* self) {
+  uint8_t* addr;
+  HSV* h;
 
-  self->tt_hsv.h += tt1.raw_state;
+  switch (self->tt_effect) {
+    case TurntableMode::STATIC:
+      addr = CONFIG_TT_STATIC_HUE_ADDR;
+      h = &self->tt_static_hsv;
+      break;
+    case TurntableMode::SPIN:
+      addr = CONFIG_TT_SPIN_HUE_ADDR;
+      h = &self->tt_spin_hsv;
+      break;
+    case TurntableMode::REACT:
+      addr = CONFIG_TT_REACT_HUE_ADDR;
+      h = &self->tt_react_hsv;
+      break;
+    case TurntableMode::BREATHING:
+      addr = CONFIG_TT_BREATHING_HUE_ADDR;
+      h = &self->tt_breathing_hsv;
+      break;
+    default:
+      return callback{};
+  }
+
+  h->h += tt1.raw_state;
+
+  return callback{addr, h->h};
 }
 
-void tt_hsv_update_hue(config* self) {
-  eeprom_update_byte(CONFIG_TT_HSV_HUE_ADDR, self->tt_hsv.h);
+callback tt_hsv_set_sat(config* self) {
+  uint8_t* addr;
+  HSV* s;
+
+  switch (self->tt_effect) {
+    case TurntableMode::STATIC:
+      addr = CONFIG_TT_STATIC_SAT_ADDR;
+      s = &self->tt_static_hsv;
+      break;
+    case TurntableMode::SHIFT:
+      addr = CONFIG_TT_SHIFT_SAT_ADDR;
+      s = &self->tt_shift_hsv;
+      break;
+    case TurntableMode::REACT:
+      addr = CONFIG_TT_REACT_SAT_ADDR;
+      s = &self->tt_react_hsv;
+      break;
+    case TurntableMode::BREATHING:
+      addr = CONFIG_TT_BREATHING_SAT_ADDR;
+      s = &self->tt_breathing_hsv;
+      break;
+    default:
+      return callback{};
+  }
+
+  const auto tt1_report = tt1.raw_state;
+
+  if ((s->s == 0 && tt1_report < 0) ||
+      (s->s == 255 && tt1_report > 0)) // prevent looping around
+    return callback{};
+
+  s->s += tt1_report;
+
+  return callback{addr, s->s};
 }
 
-void tt_hsv_set_sat(config* self) {
-  if (self->tt_effect != RgbManager::Turntable::Mode::STATIC)
-    return;
+callback tt_hsv_set_val(config* self) {
+  uint8_t* addr;
+  HSV* v;
 
-  auto tt1_report = tt1.raw_state;
+  switch (self->tt_effect) {
+    case TurntableMode::STATIC:
+      addr = CONFIG_TT_STATIC_VAL_ADDR;
+      v = &self->tt_static_hsv;
+      break;
+    case TurntableMode::SHIFT:
+      addr = CONFIG_TT_SHIFT_VAL_ADDR;
+      v = &self->tt_shift_hsv;
+      break;
+    default:
+      return callback{};
+  }
 
-  if ((self->tt_hsv.s == 0 && tt1_report < 0) ||
-      (self->tt_hsv.s == 255 && tt1_report > 0)) // prevent looping around
-    return;
+  const auto tt1_report = tt1.raw_state;
 
-  self->tt_hsv.s += tt1_report;
+  if ((v->v == 0 && tt1_report < 0) ||
+      (v->v == 255 && tt1_report > 0)) // prevent looping around
+    return callback{};
+
+  v->v += tt1_report;
+
+  return callback{addr, v->v};
 }
 
-void tt_hsv_update_sat(config* self) {
-  eeprom_update_byte(CONFIG_TT_HSV_SAT_ADDR, self->tt_hsv.s);
-}
-
-void tt_hsv_set_val(config* self) {
-  if (self->tt_effect != RgbManager::Turntable::Mode::STATIC)
-    return;
-
-  auto tt1_report = tt1.raw_state;
-
-  if ((self->tt_hsv.v == 0 && tt1_report < 0) ||
-      (self->tt_hsv.v == 255 && tt1_report > 0)) // prevent looping around
-    return;
-
-  self->tt_hsv.v += tt1_report;
-}
-
-void tt_hsv_update_val(config* self) {
-  eeprom_update_byte(CONFIG_TT_HSV_VAL_ADDR, self->tt_hsv.v);
-}
-
-void display_tt_change(uint8_t deadzone, int range) {
+void display_tt_change(const uint8_t deadzone, const int range) {
   RgbManager::Turntable::display_tt_change(deadzone, range);
-  timer_arm(&RgbManager::Turntable::combo_timer, CONFIG_CHANGE_NOTIFY_TIME);
+  timer_arm(&RgbManager::Turntable::combo_timer,
+            CONFIG_CHANGE_NOTIFY_TIME);
 }
 
 #define DEADZONE_MAX 6
 #define DEADZONE_MIN 1
-void increase_deadzone(config* self) {
+callback increase_deadzone(config* self) {
   if (++self->tt_deadzone > DEADZONE_MAX) {
     self->tt_deadzone = DEADZONE_MAX;
   }
@@ -153,9 +230,11 @@ void increase_deadzone(config* self) {
   tt1.deadzone = self->tt_deadzone;
 
   display_tt_change(self->tt_deadzone, DEADZONE_MAX);
+
+  return callback{};
 }
 
-void decrease_deadzone(config* self) {
+callback decrease_deadzone(config* self) {
   if (--self->tt_deadzone < DEADZONE_MIN) {
     self->tt_deadzone = DEADZONE_MIN;
   }
@@ -164,26 +243,31 @@ void decrease_deadzone(config* self) {
   tt1.deadzone = self->tt_deadzone;
 
   display_tt_change(self->tt_deadzone, DEADZONE_MAX);
+
+  return callback{};
 }
 
-void cycle_bar_effects(config* self) {
-  using namespace RgbManager::Bar;
+callback cycle_bar_effects(config* self) {
   do {
-    self->bar_effect = Mode((uint8_t(self->bar_effect) + 1) % uint8_t(Mode::COUNT));
-  } while (self->bar_effect == Mode::PLACEHOLDER1 ||
-           self->bar_effect == Mode::PLACEHOLDER2 ||
-           self->bar_effect == Mode::PLACEHOLDER3 ||
-           self->bar_effect == Mode::PLACEHOLDER4);
+    self->bar_effect = BarMode((uint8_t(self->bar_effect) + 1) % uint8_t(BarMode::COUNT));
+  } while (self->bar_effect == BarMode::PLACEHOLDER1 ||
+           self->bar_effect == BarMode::PLACEHOLDER2 ||
+           self->bar_effect == BarMode::PLACEHOLDER3 ||
+           self->bar_effect == BarMode::PLACEHOLDER4);
   eeprom_write_byte(CONFIG_BAR_EFFECT_ADDR, uint8_t(self->bar_effect));
 
-  set_leds_off();
+  RgbManager::Bar::set_leds_off();
+
+  return callback{};
 }
 
-void toggle_disable_led(config* self) {
+callback toggle_disable_led(config* self) {
   self->disable_led ^= 1;
 
   eeprom_write_byte(CONFIG_DISABLE_LED_ADDR, self->disable_led);
 
   if (self->disable_led)
     FastLED.clear(true);
+
+  return callback{};
 }

--- a/fw/config.cpp
+++ b/fw/config.cpp
@@ -1,4 +1,3 @@
-#pragma region Addresses
 #define CONFIG_BASE_ADDR (uint8_t*)2
 #define CONFIG_VERSION_ADDR (CONFIG_BASE_ADDR + offsetof(config, version))
 #define CONFIG_REVERSE_TT_ADDR (CONFIG_BASE_ADDR + offsetof(config, reverse_tt))
@@ -22,7 +21,6 @@
 #define CONFIG_TT_REACT_SAT_ADDR (CONFIG_BASE_ADDR + offsetof(config, tt_react_hsv.s))
 #define CONFIG_TT_BREATHING_HUE_ADDR (CONFIG_BASE_ADDR + offsetof(config, tt_breathing_hsv.h))
 #define CONFIG_TT_BREATHING_SAT_ADDR (CONFIG_BASE_ADDR + offsetof(config, tt_breathing_hsv.s))
-#pragma endregion Addresses
 
 #define CONFIG_VERSION 7
 #define MAGIC 0xBEEF

--- a/fw/config.h
+++ b/fw/config.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "pin.h"
-#include "rgb_manager.h"
+#include "rgb.h"
 
 #define CONFIG_ALL_HW_PIN { \
   CONFIG_HW_PIN(E0, E1),  /* BUTTON 1  */ \
@@ -34,32 +34,38 @@
 static_assert(BEEF_TT_RATIO != 0, "BEEF_TT_RATIO must not be 0");
 
 // Do not reorder these fields
-typedef struct {
+struct config {
   uint8_t version;
   uint8_t reverse_tt;
-  RgbManager::Turntable::Mode tt_effect;
+  TurntableMode tt_effect;
   uint8_t tt_deadzone;
-  RgbManager::Bar::Mode bar_effect;
+  BarMode bar_effect;
   uint8_t disable_led;
-  HSV tt_hsv;
-} config;
+  HSV tt_static_hsv;
+  HSV tt_spin_hsv;
+  HSV tt_shift_hsv;
+  HSV tt_react_hsv;
+  HSV tt_breathing_hsv;
+};
+
+struct callback {
+  uint8_t* addr;
+  uint8_t val;
+};
 
 void config_init(config* self);
-void toggle_reverse_tt(config* self);
-void cycle_tt_effects(config* self);
-void tt_hsv_set_hue(config* self);
-void tt_hsv_update_hue(config* self);
-void tt_hsv_set_sat(config* self);
-void tt_hsv_update_sat(config* self);
-void tt_hsv_set_val(config* self);
-void tt_hsv_update_val(config* sel);
-void increase_deadzone(config* self);
-void decrease_deadzone(config* self);
-void cycle_bar_effects(config* self);
-void toggle_disable_led(config* self);
+void config_update(uint8_t* addr, uint8_t val);
+callback toggle_reverse_tt(config* self);
+callback cycle_tt_effects(config* self);
+callback tt_hsv_set_hue(config* self);
+callback tt_hsv_set_sat(config* self);
+callback tt_hsv_set_val(config* self);
+callback increase_deadzone(config* self);
+callback decrease_deadzone(config* self);
+callback cycle_bar_effects(config* self);
+callback toggle_disable_led(config* self);
 
 // button combos
-#define NUM_OF_COMBOS 9
 #define REVERSE_TT_COMBO (BUTTON_1 | BUTTON_7 | BUTTON_8)
 #define TT_EFFECTS_COMBO (BUTTON_2 | BUTTON_8 | BUTTON_11)
 #define TT_DEADZONE_INCR_COMBO (BUTTON_3 | BUTTON_8 | BUTTON_11)

--- a/fw/config.h
+++ b/fw/config.h
@@ -44,6 +44,9 @@ struct config {
   HSV tt_static_hsv;
   HSV tt_spin_hsv;
   HSV tt_shift_hsv;
+  HSV tt_rainbow_static_hsv;
+  HSV tt_rainbow_react_hsv;
+  HSV tt_rainbow_spin_hsv;
   HSV tt_react_hsv;
   HSV tt_breathing_hsv;
 };

--- a/fw/rgb.h
+++ b/fw/rgb.h
@@ -2,16 +2,40 @@
 
 #include <stdint.h>
 
-typedef struct {
+struct rgb_light {
   uint8_t r, g, b;
-} rgb_light;
+};
 
 struct HSV {
   uint8_t h, s, v;
 };
 
-typedef struct {
+struct hid_lights {
   uint16_t buttons;
   rgb_light tt_lights;
   rgb_light bar_lights;
-} hid_lights;
+};
+
+enum class TurntableMode : uint8_t {
+  STATIC,
+  SPIN,
+  SHIFT,
+  RAINBOW_STATIC,
+  RAINBOW_REACT,
+  RAINBOW_SPIN,
+  REACT,
+  BREATHING,
+  HID,
+  DISABLE,
+  COUNT
+};
+
+enum class BarMode : uint8_t {
+  PLACEHOLDER1, // beat
+  PLACEHOLDER2, // reactive p1
+  PLACEHOLDER3, // audio spectrum
+  PLACEHOLDER4, // reactive p2
+  HID,
+  DISABLE,
+  COUNT
+};

--- a/fw/rgb_manager.cpp
+++ b/fw/rgb_manager.cpp
@@ -72,7 +72,7 @@ namespace RgbManager {
       fill_solid(leds, RING_LIGHT_LEDS, CRGB::Black);
     }
 
-    // Render two spinning turquoise LEDs
+    // Render two spinning LEDs
     void spin(const HSV &hsv) {
       static bool first_call = true;
       static uint8_t spin_counter = 0;

--- a/fw/rgb_manager.cpp
+++ b/fw/rgb_manager.cpp
@@ -7,6 +7,7 @@
 #define TT_DATA_PIN  15 // C5
 
 #define SPIN_TIMER 50
+#define REACT_TIMER 500
 #define BREATHING_TIMER 3000
 
 namespace RgbManager {
@@ -17,15 +18,14 @@ namespace RgbManager {
 
   void set_hsv(CRGB* leds, uint8_t n, HSV hsv) {
     CRGB rgb{};
-    hsv2rgb_spectrum(CHSV{hsv.h, hsv.s, hsv.v}, rgb);
+    hsv2rgb_spectrum(CHSV(hsv.h, hsv.s, hsv.v), rgb);
     fill_solid(leds, n, rgb);
   }
 
   // Cycle from zero to full-bright to zero in around 2 seconds
   // Share same lighting state between TT and light bar
   template<int DURATION, int TIMER>
-  void breathing(CRGB* leds, int n,
-                 uint8_t h, uint8_t s) {
+  void breathing(CRGB* leds, const int n, const HSV hsv) {
     static uint8_t theta = 0;
     static Ticker sin_ticker(8, DURATION);
     static timer breathing_timer{};
@@ -42,13 +42,13 @@ namespace RgbManager {
       v = quadwave8(theta);
     }
 
-    set_hsv(leds, n, HSV{h, s, v});
+    set_hsv(leds, n, { hsv.h, hsv.s, v });
   }
 
   void hid(CRGB* leds, int n,
            rgb_light lights) {
     if (rgb_standby)
-      breathing<0, 0>(leds, n, 0, 0);
+      breathing<0, 0>(leds, n, {});
     else
       set_rgb(leds, n, lights);
   }
@@ -56,51 +56,24 @@ namespace RgbManager {
   namespace Turntable {
     timer combo_timer;
     CRGB leds[RING_LIGHT_LEDS] = {0};
-    timer scr_timer;
 
     void init() {
-      static bool inited = false;
-      if (!inited) {
-        inited = true;
+      timer_init(&combo_timer);
 
-        timer_init(&combo_timer);
-        timer_init(&scr_timer);
-
-        FastLED.addLeds<NEOPIXEL, TT_DATA_PIN>(leds, RING_LIGHT_LEDS)
-          .setDither(DISABLE_DITHER);
-      } 
-    }
-
-    void set_rgb(rgb_light lights) {
-      RgbManager::set_rgb(leds, RING_LIGHT_LEDS, lights);
+      FastLED.addLeds<NEOPIXEL, TT_DATA_PIN>(leds, RING_LIGHT_LEDS)
+        .setDither(DISABLE_DITHER);
     }
 
     void set_hsv(HSV hsv) {
       RgbManager::set_hsv(leds, RING_LIGHT_LEDS, hsv);
     }
 
-    void set_leds_blue() {
-      fill_solid(leds, RING_LIGHT_LEDS, CRGB::Blue);
-    }
-
-    void set_leds_red() {
-      fill_solid(leds, RING_LIGHT_LEDS, CRGB::Red);
-    }
-
     void set_leds_off() {
       fill_solid(leds, RING_LIGHT_LEDS, CRGB::Black);
     }
 
-    void colour_shift() {
-      static HSV hsv = { 0, 255, 255 };
-      static Ticker ticker(100);
-
-      hsv.h += ticker.get_ticks();
-      set_hsv(hsv);
-    }
-
     // Render two spinning turquoise LEDs
-    void spin() {
+    void spin(const HSV &hsv) {
       static bool first_call = true;
       static uint8_t spin_counter = 0;
       static Ticker ticker(SPIN_TIMER);
@@ -109,10 +82,20 @@ namespace RgbManager {
       if (ticks > 0 || first_call) {
         spin_counter = (spin_counter + ticks) % (RING_LIGHT_LEDS / 2);
         set_leds_off();
-        leds[spin_counter] = CRGB::Aqua;
-        leds[spin_counter+12] = CRGB::Aqua;
+
+        const auto colour = CHSV(hsv.h, 255, 255);
+        leds[spin_counter] = colour;
+        leds[spin_counter+12] = colour;
         first_call = false;
       }
+    }
+
+    void colour_shift(const HSV &hsv) {
+      static uint8_t h;
+      static Ticker ticker(100);
+
+      h += ticker.get_ticks();
+      set_hsv({ h, hsv.s, hsv.v });
     }
 
     void render_rainbow(uint8_t pos = 0) {
@@ -125,17 +108,26 @@ namespace RgbManager {
       render_rainbow(pos);
     }
 
-    void react_to_scr(int8_t tt_report) {
-      if (tt_report == 1) {
-        set_leds_blue();
-        timer_arm(&scr_timer, 500);
-      } else if (tt_report == -1) {
-        set_leds_red();
-        timer_arm(&scr_timer, 500);
+    void react(const int8_t tt_report, const HSV &hsv) {
+      static uint8_t h = hsv.h;
+      static timer scr_timer;
+
+      switch (tt_report) {
+        case 1:
+          h = hsv.h;
+          timer_arm(&scr_timer, REACT_TIMER);
+          break;
+        case -1:
+          h = hsv.h + 128;
+          timer_arm(&scr_timer, REACT_TIMER);
+          break;
+        default:
+          break;
       }
-      if (!timer_is_active(&scr_timer)) {
-        set_leds_off();
-      }
+
+      const uint8_t v = timer_is_active(&scr_timer) ? 255 : 64;
+
+      set_hsv({ h, hsv.s, v });
     }
 
     // Illuminate + as blue, - as red in two halves
@@ -164,43 +156,43 @@ namespace RgbManager {
     }
 
     // tt +1 is counter-clockwise, -1 is clockwise
-    void update(int8_t tt_report,
-                rgb_light lights,
-                HSV hsv,
-                Mode mode) {
-      // Ignore turtable effect if notifying a mode change
+    void update(const int8_t tt_report,
+                const rgb_light &lights,
+                const config &current_config) {
+      // Ignore turntable effect if notifying a mode change
       if (!timer_is_active(&combo_timer)) {
-        switch(mode) {
-          case Mode::STATIC:
-            set_hsv(hsv);
+        switch(current_config.tt_effect) {
+          case TurntableMode::STATIC:
+            set_hsv(current_config.tt_static_hsv);
             break;
-          case Mode::SHIFT:
-            colour_shift();
+          case TurntableMode::SPIN:
+            spin(current_config.tt_spin_hsv);
             break;
-          case Mode::SPIN:
-            spin();
+          case TurntableMode::SHIFT:
+            colour_shift(current_config.tt_shift_hsv);
             break;
-          case Mode::RAINBOW_STATIC:
+          case TurntableMode::RAINBOW_STATIC:
             render_rainbow();
             break;
-          case Mode::RAINBOW_REACT:
+          case TurntableMode::RAINBOW_REACT:
             render_rainbow_pos(tt_report);
             break;
-          case Mode::RAINBOW_SPIN:
+          case TurntableMode::RAINBOW_SPIN:
             render_rainbow_pos(1);
             break;
-          case Mode::REACT_TO_SCR:
-            react_to_scr(tt_report);
+          case TurntableMode::REACT:
+            react(tt_report, current_config.tt_react_hsv);
             break;
-          case Mode::BREATHING:
+          case TurntableMode::BREATHING:
             // Add a second-long rest period
-            breathing<2048, BREATHING_TIMER>(leds, RING_LIGHT_LEDS,
-              default_colour.h, default_colour.s);
+            breathing<2048, BREATHING_TIMER>(
+              leds, RING_LIGHT_LEDS,
+              current_config.tt_breathing_hsv);
             break;
-          case Mode::HID:
+          case TurntableMode::HID:
             hid(leds, RING_LIGHT_LEDS, lights);
             break;
-          case Mode::DISABLE:
+          case TurntableMode::DISABLE:
             set_leds_off();
             break;
           default:
@@ -214,35 +206,31 @@ namespace RgbManager {
     CRGB leds[LIGHT_BAR_LEDS] = {0};
 
     void init() {
-      static bool inited = false;
-      if (!inited) {
-        inited = true;
-
-        FastLED.addLeds<NEOPIXEL, BAR_DATA_PIN>(leds, LIGHT_BAR_LEDS)
-          .setDither(DISABLE_DITHER);
-      }
-    }
-
-    void set_rgb(rgb_light lights) {
-      RgbManager::set_rgb(leds, LIGHT_BAR_LEDS, lights);
+      FastLED.addLeds<NEOPIXEL, BAR_DATA_PIN>(leds, LIGHT_BAR_LEDS)
+        .setDither(DISABLE_DITHER);
     }
 
     void set_leds_off() {
       fill_solid(leds, LIGHT_BAR_LEDS, CRGB::Black);
     }
 
-    void update(rgb_light lights,
-                Mode mode) {
-      switch(mode) {
-        case Mode::HID:
+    void update(const rgb_light &lights,
+                const config &current_config) {
+      switch(current_config.bar_effect) {
+        case BarMode::HID:
           hid(leds, LIGHT_BAR_LEDS, lights);
           break;
-        case Mode::DISABLE:
+        case BarMode::DISABLE:
           set_leds_off();
           break;
         default:
           break;
       }
     }
+  }
+
+  void init() {
+    Turntable::init();
+    Bar::init();
   }
 }

--- a/fw/rgb_manager.h
+++ b/fw/rgb_manager.h
@@ -1,61 +1,33 @@
 #pragma once
 
-#include "FastLED/src/FastLED.h"
+#include <FastLED/src/FastLED.h>
 
+#include "config.h"
 #include "rgb.h"
 #include "timer.h"
 
 #define RING_LIGHT_LEDS 24
 #define LIGHT_BAR_LEDS 16
 
-const auto default_colour = HSV{ 127, 255, 255 }; // Aqua
+constexpr auto DEFAULT_COLOUR = HSV{ 127, 255, 255 }; // Aqua
 
 namespace RgbManager {
+  void init();
+
   namespace Turntable {
     extern timer combo_timer;
 
-    // tentative names for LED ring modes
-    enum class Mode : uint8_t {
-      STATIC,
-      SPIN,
-      SHIFT,
-      RAINBOW_STATIC,
-      RAINBOW_REACT,
-      RAINBOW_SPIN,
-      REACT_TO_SCR,
-      BREATHING,
-      HID,
-      DISABLE,
-      COUNT
-    };
-
-    void init();
-    void set_rgb(rgb_light lights);
-    void set_hsv(HSV hsv);
     void set_leds_off();
     void reverse_tt(uint8_t reverse_tt);
     void display_tt_change(uint8_t deadzone, int range);
     void update(int8_t tt_report,
-                rgb_light lights,
-                HSV hsv,
-                Mode mode);
+                const rgb_light &lights,
+                const config &current_config);
   }
 
   namespace Bar {
-    enum class Mode : uint8_t {
-      PLACEHOLDER1, // beat
-      PLACEHOLDER2, // reactive p1
-      PLACEHOLDER3, // audio spectrum
-      PLACEHOLDER4, // reactive p2
-      HID,
-      DISABLE,
-      COUNT
-    };
-
-    void init();
-    void set_rgb(rgb_light lights);
     void set_leds_off();
-    void update(rgb_light lights,
-                Mode mode);
+    void update(const rgb_light &lights,
+                const config &current_config);
   }
 }


### PR DESCRIPTION
Closes #54.

* Add HSV adjustments for all TT light modes
* Use `offsetof()` to get EEPROM offsets
* Updated continuous hold combo behaviour
  * If an invalid combo is being held for the TT light mode, it will blank out the button LEDs as an indicator
  * This also works if the upper/lower limit for sat and val are being hit
* Updated `REACT_TO_SCR` effect
  * Renamed to `REACT`
  * Still keeps the two-tone effect, except it lowers the brightness instead of being off akin to stock
* Various code clean up