### PR TITLE
Update FastLED to 3.7.0

### DIFF
--- a/fw/makefile
+++ b/fw/makefile
@@ -55,4 +55,4 @@ fuse-dump:
 # flash the factory DFU bootloader
 .PHONY: bootloader
 bootloader:
-        sudo avrdude -c stk500v1 -b 19200 -p $(MCU) -P /dev/ttyACM0 -U flash:w:$(BOOTLOADER).hex
+	sudo avrdude -c stk500v1 -b 19200 -p $(MCU) -P /dev/ttyACM0 -U flash:w:$(BOOTLOADER).hex

--- a/fw/rgb_helper.cpp
+++ b/fw/rgb_helper.cpp
@@ -14,9 +14,10 @@ namespace RgbHelper {
 
   void init() {
     FastLED.addLeds<NEOPIXEL, TT_DATA_PIN>(tt_leds, RING_LIGHT_LEDS)
-        .setDither(DISABLE_DITHER);
+      .setDither(DISABLE_DITHER);
     FastLED.addLeds<NEOPIXEL, BAR_DATA_PIN>(bar_leds, LIGHT_BAR_LEDS)
-        .setDither(DISABLE_DITHER);
+      .setDither(DISABLE_DITHER);
+    FastLED.setMaxRefreshRate(0); // We have our own frame rate limiter
   }
 
   void set_rgb(CRGB* leds, const uint8_t n, const rgb_light &lights) {


### PR DESCRIPTION
FastLED's 3.7.0 changelog on their Github release page is pretty lacking, but here's a [Reddit thread](https://www.reddit.com/r/FastLED/comments/1d1wyzp/fastled_370_release/) that's better. Of note are the new AVR specific optimisations, reduced compiler warnings and faster build times.

Also:
* Fix syntax error in `makefile`
* Set FastLED's frame limiter to 0
  * Minor optimisation since we do our own frame limiting, so we skip FastLED's own checks