### PR TITLE
Handle suspend/wake events, fix buttons not being ignored after plug in

### DIFF
--- a/fw/beef.h
+++ b/fw/beef.h
@@ -22,13 +22,14 @@ void set_led(volatile uint8_t* PORT,
 void set_hid_standby_lighting();
 void process_buttons();
 void process_button(const volatile uint8_t* PIN,
-                    uint8_t button_number,
-                    uint8_t input_pin);
+                    const uint8_t button_number,
+                    const uint8_t input_pin);
 void update_tt_transitions(bool reverse_tt);
 void process_keyboard(Beef::USB_KeyboardReport_Data_t* const hid_key_codes,
                       const uint8_t* const key_codes,
                       const uint8_t n);
 void update_button_lighting(uint16_t led_state);
+void clear_all_lights();
 
 void debounce(DebounceState &debounce, uint16_t mask);
 bool is_only_pressed(uint16_t button_bits, uint16_t ignore = 0);

--- a/fw/config.cpp
+++ b/fw/config.cpp
@@ -4,7 +4,7 @@
 #define CONFIG_TT_EFFECT_ADDR (CONFIG_BASE_ADDR + offsetof(config, tt_effect))
 #define CONFIG_TT_DEADZONE_ADDR (CONFIG_BASE_ADDR + offsetof(config, tt_deadzone))
 #define CONFIG_BAR_EFFECT_ADDR (CONFIG_BASE_ADDR + offsetof(config, bar_effect))
-#define CONFIG_DISABLE_LED_ADDR (CONFIG_BASE_ADDR + offsetof(config, disable_led))
+#define CONFIG_DISABLE_LEDS_ADDR (CONFIG_BASE_ADDR + offsetof(config, disable_leds))
 #define CONFIG_TT_STATIC_HUE_ADDR (CONFIG_BASE_ADDR + offsetof(config, tt_static_hsv.h))
 #define CONFIG_TT_STATIC_SAT_ADDR (CONFIG_BASE_ADDR + offsetof(config, tt_static_hsv.s))
 #define CONFIG_TT_STATIC_VAL_ADDR (CONFIG_BASE_ADDR + offsetof(config, tt_static_hsv.v))
@@ -57,7 +57,7 @@ bool update_config(config* self) {
       self->bar_effect = BarMode::HID;
       self->version++;
     case 3:
-      self->disable_led = 0;
+      self->disable_leds = 0;
       self->version++;
     case 4:
       self->tt_static_hsv = DEFAULT_COLOUR;
@@ -155,14 +155,14 @@ void config_save(const config &new_config) {
     IIDX::RgbManager::Bar::set_leds_off();
     IIDX::RgbManager::Bar::force_update = true;
   }
-  if (new_config.disable_led) {
+  if (new_config.disable_leds) {
     FastLED.clear(true);
   }
   update_tt_transitions(new_config.reverse_tt);
 
   current_config = new_config;
   current_config.reverse_tt &= 1;
-  current_config.disable_led &= 1;
+  current_config.disable_leds &= 1;
   eeprom_update_block(&current_config, CONFIG_BASE_ADDR, sizeof(config));
 }
 
@@ -382,13 +382,14 @@ callback cycle_bar_effects(config* self) {
   return callback{};
 }
 
-callback toggle_disable_led(config* self) {
-  self->disable_led ^= 1;
+callback toggle_disable_leds(config* self) {
+  self->disable_leds ^= 1;
 
-  eeprom_write_byte(CONFIG_DISABLE_LED_ADDR, self->disable_led);
+  eeprom_write_byte(CONFIG_DISABLE_LEDS_ADDR, self->disable_leds);
 
-  if (self->disable_led)
+  if (self->disable_leds) {
     FastLED.clear(true);
+  }
 
   return callback{};
 }

--- a/fw/config.h
+++ b/fw/config.h
@@ -58,7 +58,7 @@ struct config {
   TurntableMode tt_effect;
   uint8_t tt_deadzone;
   BarMode bar_effect;
-  uint8_t disable_led;
+  uint8_t disable_leds;
   HSV tt_static_hsv;
   HSV tt_spin_hsv;
   HSV tt_shift_hsv;
@@ -97,4 +97,4 @@ callback decrease_deadzone(config* self);
 callback increase_ratio(config* self);
 callback decrease_ratio(config* self);
 callback cycle_bar_effects(config* self);
-callback toggle_disable_led(config* self);
+callback toggle_disable_leds(config* self);

--- a/fw/devices/iidx/iidx_combo.cpp
+++ b/fw/devices/iidx/iidx_combo.cpp
@@ -51,7 +51,7 @@ namespace IIDX {
         };
       case DISABLE_LED:
         return {
-            .config_set = toggle_disable_led
+            .config_set = toggle_disable_leds
         };
       case TT_HSV_HUE:
         return {

--- a/fw/devices/sdvx/sdvx_combo.cpp
+++ b/fw/devices/sdvx/sdvx_combo.cpp
@@ -10,7 +10,7 @@ namespace SDVX {
     switch (button_state) {
       case DISABLE_LED:
         return {
-            .config_set = toggle_disable_led
+            .config_set = toggle_disable_leds
         };
       default:
         return {};

--- a/fw/rgb_helper.cpp
+++ b/fw/rgb_helper.cpp
@@ -66,7 +66,7 @@ namespace RgbHelper {
   // computationally expensive calls to FastLED.show()
   // basically what FastLED does but without spin waiting
   bool ready_to_present() {
-    if (current_config.disable_led)
+    if (current_config.disable_leds)
       return false;
 
     static uint32_t last_show = 0;


### PR DESCRIPTION
Closes #99.

Now handles sleep/wake events.
Disables all processing and lights during sleep. The board can still respond to USB control events since they're handled in an interrupt, but all other USB reports will get ignored/won't be sent. TBH I'm a bit uncertain about this, so if this should be changed I'll happily do so.

I also renamed the `disable_led` field to `disable_leds` to make it consistent with our web config tool.

Also oops somehow broke the `ignore_buttons` check.