### PR TITLE
Implement DFU flashing in web config

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ There also exist button combinations which perform special actions if held while
   * RGB HID functionality
   * FastLED shims
   * Debounce code
+* [dfu-programmer](https://github.com/dfu-programmer/dfu-programmer) for serving as the reference implementation for the Atmel DFU protocol
 * Special thanks to Mechada and Cryto for beta testing
 
 # PCB APPROVED BY KORS K

--- a/beef-config/package-lock.json
+++ b/beef-config/package-lock.json
@@ -8,8 +8,11 @@
 			"name": "beef-config",
 			"version": "0.0.1",
 			"dependencies": {
+				"buffer": "^6.0.3",
 				"clsx": "^2.1.1",
+				"eventemitter3": "^5.0.1",
 				"lucide-svelte": "^0.441.0",
+				"nrf-intel-hex": "^1.4.0",
 				"tailwind-merge": "^2.5.2",
 				"tailwind-variants": "^0.2.1"
 			},
@@ -23,6 +26,7 @@
 				"@types/estree": "^1.0.6",
 				"@types/json-schema": "^7.0.15",
 				"@types/w3c-web-hid": "^1.0.6",
+				"@types/w3c-web-usb": "^1.0.10",
 				"autoprefixer": "^10.4.20",
 				"bits-ui": "^0.21.16",
 				"eslint": "^9.0.0",
@@ -238,9 +242,9 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "9.12.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.12.0.tgz",
-			"integrity": "sha512-eohesHH8WFRUprDNyEREgqP6beG6htMeUYeCpkEgBCieCMme5r9zFWjzAJp//9S+Kub4rqE+jXe9Cp1a7IYIIA==",
+			"version": "9.19.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.19.0.tgz",
+			"integrity": "sha512-rbq9/g38qjfqFLOVPvwjIvFFdNziEC5S65jmjPw5r6A//QH+W91akh9irMwjDN8zKUTak6W9EsAv4m/7Wnw0UQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -258,43 +262,6 @@
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			}
-		},
-		"node_modules/@eslint/plugin-kit/node_modules/levn": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"prelude-ls": "^1.2.1",
-				"type-check": "~0.4.0"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/@eslint/plugin-kit/node_modules/prelude-ls": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/@eslint/plugin-kit/node_modules/type-check": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"prelude-ls": "^1.2.1"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
 			}
 		},
 		"node_modules/@floating-ui/core": {
@@ -1024,10 +991,29 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/node": {
+			"version": "22.12.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.12.0.tgz",
+			"integrity": "sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"undici-types": "~6.20.0"
+			}
+		},
 		"node_modules/@types/w3c-web-hid": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/@types/w3c-web-hid/-/w3c-web-hid-1.0.6.tgz",
 			"integrity": "sha512-IWyssXmRDo6K7s31dxf+U+x/XUWuVsl9qUIYbJmpUHPcTv/COfBCKw/F0smI45+gPV34brjyP30BFcIsHgYWLA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/w3c-web-usb": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/@types/w3c-web-usb/-/w3c-web-usb-1.0.10.tgz",
+			"integrity": "sha512-CHgUI5kTc/QLMP8hODUHhge0D4vx+9UiAwIGiT0sTy/B2XpdX1U5rJt6JSISgr6ikRT7vxV9EVAFeYZqUnl1gQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1065,24 +1051,6 @@
 				}
 			}
 		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.6.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.6.0.tgz",
-			"integrity": "sha512-ZuoutoS5y9UOxKvpc/GkvF4cuEmpokda4wRg64JEia27wX+PysIE9q+lzDtlHHgblwUWwo5/Qn+/WyTUvDwBHw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/types": "8.6.0",
-				"@typescript-eslint/visitor-keys": "8.6.0"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils": {
 			"version": "8.6.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.6.0.tgz",
@@ -1108,115 +1076,12 @@
 				}
 			}
 		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
-			"version": "8.6.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.6.0.tgz",
-			"integrity": "sha512-rojqFZGd4MQxw33SrOy09qIDS8WEldM8JWtKQLAjf/X5mGSeEFh5ixQlxssMNyPslVIk9yzWqXCsV2eFhYrYUw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.6.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.6.0.tgz",
-			"integrity": "sha512-MOVAzsKJIPIlLK239l5s06YXjNqpKTVhBVDnqUumQJja5+Y94V3+4VUFRA0G60y2jNnTVwRCkhyGQpavfsbq/g==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"@typescript-eslint/types": "8.6.0",
-				"@typescript-eslint/visitor-keys": "8.6.0",
-				"debug": "^4.3.4",
-				"fast-glob": "^3.3.2",
-				"is-glob": "^4.0.3",
-				"minimatch": "^9.0.4",
-				"semver": "^7.6.0",
-				"ts-api-utils": "^1.3.0"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.6.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.6.0.tgz",
-			"integrity": "sha512-wapVFfZg9H0qOYh4grNVQiMklJGluQrOUiOhYRrQWhx7BY/+I1IYb8BczWNbbUpO+pqy0rDciv3lQH5E1bCLrg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/types": "8.6.0",
-				"eslint-visitor-keys": "^3.4.3"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/eslint-visitor-keys": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/graphemer": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
 			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/ts-api-utils": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
-			"integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=16"
-			},
-			"peerDependencies": {
-				"typescript": ">=4.2.0"
-			}
 		},
 		"node_modules/@typescript-eslint/parser": {
 			"version": "8.6.0",
@@ -1247,7 +1112,7 @@
 				}
 			}
 		},
-		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+		"node_modules/@typescript-eslint/scope-manager": {
 			"version": "8.6.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.6.0.tgz",
 			"integrity": "sha512-ZuoutoS5y9UOxKvpc/GkvF4cuEmpokda4wRg64JEia27wX+PysIE9q+lzDtlHHgblwUWwo5/Qn+/WyTUvDwBHw==",
@@ -1265,7 +1130,7 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+		"node_modules/@typescript-eslint/types": {
 			"version": "8.6.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.6.0.tgz",
 			"integrity": "sha512-rojqFZGd4MQxw33SrOy09qIDS8WEldM8JWtKQLAjf/X5mGSeEFh5ixQlxssMNyPslVIk9yzWqXCsV2eFhYrYUw==",
@@ -1279,7 +1144,7 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+		"node_modules/@typescript-eslint/typescript-estree": {
 			"version": "8.6.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.6.0.tgz",
 			"integrity": "sha512-MOVAzsKJIPIlLK239l5s06YXjNqpKTVhBVDnqUumQJja5+Y94V3+4VUFRA0G60y2jNnTVwRCkhyGQpavfsbq/g==",
@@ -1308,38 +1173,7 @@
 				}
 			}
 		},
-		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.6.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.6.0.tgz",
-			"integrity": "sha512-wapVFfZg9H0qOYh4grNVQiMklJGluQrOUiOhYRrQWhx7BY/+I1IYb8BczWNbbUpO+pqy0rDciv3lQH5E1bCLrg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/types": "8.6.0",
-				"eslint-visitor-keys": "^3.4.3"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/parser/node_modules/minimatch": {
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
 			"version": "9.0.5",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
 			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
@@ -1353,19 +1187,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@typescript-eslint/parser/node_modules/ts-api-utils": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
-			"integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=16"
-			},
-			"peerDependencies": {
-				"typescript": ">=4.2.0"
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
@@ -1391,68 +1212,7 @@
 				"eslint": "^8.57.0 || ^9.0.0"
 			}
 		},
-		"node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.6.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.6.0.tgz",
-			"integrity": "sha512-ZuoutoS5y9UOxKvpc/GkvF4cuEmpokda4wRg64JEia27wX+PysIE9q+lzDtlHHgblwUWwo5/Qn+/WyTUvDwBHw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/types": "8.6.0",
-				"@typescript-eslint/visitor-keys": "8.6.0"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
-			"version": "8.6.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.6.0.tgz",
-			"integrity": "sha512-rojqFZGd4MQxw33SrOy09qIDS8WEldM8JWtKQLAjf/X5mGSeEFh5ixQlxssMNyPslVIk9yzWqXCsV2eFhYrYUw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.6.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.6.0.tgz",
-			"integrity": "sha512-MOVAzsKJIPIlLK239l5s06YXjNqpKTVhBVDnqUumQJja5+Y94V3+4VUFRA0G60y2jNnTVwRCkhyGQpavfsbq/g==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"@typescript-eslint/types": "8.6.0",
-				"@typescript-eslint/visitor-keys": "8.6.0",
-				"debug": "^4.3.4",
-				"fast-glob": "^3.3.2",
-				"is-glob": "^4.0.3",
-				"minimatch": "^9.0.4",
-				"semver": "^7.6.0",
-				"ts-api-utils": "^1.3.0"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
+		"node_modules/@typescript-eslint/visitor-keys": {
 			"version": "8.6.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.6.0.tgz",
 			"integrity": "sha512-wapVFfZg9H0qOYh4grNVQiMklJGluQrOUiOhYRrQWhx7BY/+I1IYb8BczWNbbUpO+pqy0rDciv3lQH5E1bCLrg==",
@@ -1470,7 +1230,7 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"node_modules/@typescript-eslint/utils/node_modules/eslint-visitor-keys": {
+		"node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
 			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
@@ -1483,33 +1243,26 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/@typescript-eslint/utils/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
+		"node_modules/acorn": {
+			"version": "8.14.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+			"integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+			"license": "MIT",
+			"bin": {
+				"acorn": "bin/acorn"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
+				"node": ">=0.4.0"
 			}
 		},
-		"node_modules/@typescript-eslint/utils/node_modules/ts-api-utils": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
-			"integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
+		"node_modules/acorn-jsx": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
 			"dev": true,
 			"license": "MIT",
-			"engines": {
-				"node": ">=16"
-			},
 			"peerDependencies": {
-				"typescript": ">=4.2.0"
+				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
 		"node_modules/ajv": {
@@ -1640,6 +1393,26 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"license": "MIT"
 		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/bits-ui": {
 			"version": "0.21.16",
 			"resolved": "https://registry.npmjs.org/bits-ui/-/bits-ui-0.21.16.tgz",
@@ -1710,6 +1483,30 @@
 			},
 			"engines": {
 				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+			}
+		},
+		"node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
 			}
 		},
 		"node_modules/camelcase-css": {
@@ -2215,9 +2012,9 @@
 			}
 		},
 		"node_modules/eslint-scope": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.0.2.tgz",
-			"integrity": "sha512-6E4xmrTw5wtxnLA5wYL3WDfhZ/1bUBGOXV0zQvVRDOtrR8D0p6W7fs3JweNYhwRYeGvd/1CKX2se0/2s7Q/nJA==",
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz",
+			"integrity": "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
@@ -2231,33 +2028,10 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/eslint-scope/node_modules/esrecurse": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"estraverse": "^5.2.0"
-			},
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
-		"node_modules/eslint-scope/node_modules/estraverse": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
 		"node_modules/eslint-visitor-keys": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
-			"integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+			"integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -2278,44 +2052,21 @@
 			}
 		},
 		"node_modules/espree": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-10.1.0.tgz",
-			"integrity": "sha512-M1M6CpiE6ffoigIOWYO9UDP8TMUw9kqb21tf+08IgDYjCsOvCuDt4jQcZmoYxx+w7zlKw9/N0KXfto+I8/FrXA==",
+			"version": "10.3.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
+			"integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"acorn": "^8.12.0",
+				"acorn": "^8.14.0",
 				"acorn-jsx": "^5.3.2",
-				"eslint-visitor-keys": "^4.0.0"
+				"eslint-visitor-keys": "^4.2.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/espree/node_modules/acorn": {
-			"version": "8.12.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-			"integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"acorn": "bin/acorn"
-			},
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/espree/node_modules/acorn-jsx": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"dev": true,
-			"license": "MIT",
-			"peerDependencies": {
-				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
 		"node_modules/esquery": {
@@ -2331,7 +2082,20 @@
 				"node": ">=0.10"
 			}
 		},
-		"node_modules/esquery/node_modules/estraverse": {
+		"node_modules/esrecurse": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"estraverse": "^5.2.0"
+			},
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/estraverse": {
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
@@ -2350,6 +2114,12 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/eventemitter3": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+			"integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+			"license": "MIT"
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
@@ -2647,9 +2417,9 @@
 			}
 		},
 		"node_modules/globals": {
-			"version": "15.9.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-15.9.0.tgz",
-			"integrity": "sha512-SmSKyLLKFbSr6rptvP8izbyxJL4ILwqO9Jg23UA0sDlGlu58V59D1//I3vlc0KJphVdUR7vMjHIplYnzBxorQA==",
+			"version": "15.14.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-15.14.0.tgz",
+			"integrity": "sha512-OkToC372DtlQeje9/zHIo5CT8lRP/FUgEOKBEhU4e0abL7J7CD24fD9ohiLN5hagG/kWCYj4K5oaxxtj2Z0Dig==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2670,6 +2440,26 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/ignore": {
 			"version": "5.3.2",
@@ -2814,6 +2604,20 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/levn": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"prelude-ls": "^1.2.1",
+				"type-check": "~0.4.0"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
 		"node_modules/lilconfig": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
@@ -2934,9 +2738,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.7.tgz",
-			"integrity": "sha512-oLxFY2gd2IqnjcYyOXD8XGCftpGtZP2AbHbOkthDkvRywH5ayNtPVy9YlOPcHckXzbLTCHpkb7FB+yuxKV13pQ==",
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.9.tgz",
+			"integrity": "sha512-Aooyr6MXU6HpvvWXKoVoXwKMs/KyVakWwg7xQfv5/S/RIgJMy0Ifa45H9qqYy7pTCszrHzP21Uk4PZq2HpEM8Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -2983,6 +2787,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/nrf-intel-hex": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/nrf-intel-hex/-/nrf-intel-hex-1.4.0.tgz",
+			"integrity": "sha512-q3+GGRIpe0VvCjUP1zaqW5rk6IpCZzhD0lu7Sguo1bgWwFcA9kZRjsaKUb0jBQMnefyOl5o0BBGAxvqMqYx8Sg==",
+			"license": "BSD",
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/object-assign": {
@@ -3034,43 +2847,6 @@
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/optionator/node_modules/levn": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"prelude-ls": "^1.2.1",
-				"type-check": "~0.4.0"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/optionator/node_modules/prelude-ls": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/optionator/node_modules/type-check": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"prelude-ls": "^1.2.1"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
 		},
 		"node_modules/optionator/node_modules/word-wrap": {
 			"version": "1.2.5",
@@ -3317,12 +3093,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/postcss-selector-parser/node_modules/util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-			"license": "MIT"
-		},
 		"node_modules/postcss-value-parser": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
@@ -3330,9 +3100,9 @@
 			"license": "MIT"
 		},
 		"node_modules/postcss/node_modules/nanoid": {
-			"version": "3.3.7",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-			"integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+			"version": "3.3.8",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+			"integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
 			"funding": [
 				{
 					"type": "github",
@@ -3347,13 +3117,14 @@
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
 		},
-		"node_modules/postcss/node_modules/source-map-js": {
+		"node_modules/prelude-ls": {
 			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-			"license": "BSD-3-Clause",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+			"dev": true,
+			"license": "MIT",
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">= 0.8.0"
 			}
 		},
 		"node_modules/prettier": {
@@ -3569,6 +3340,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/source-map-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/string-width": {
@@ -3826,29 +3606,6 @@
 				}
 			}
 		},
-		"node_modules/svelte-eslint-parser/node_modules/acorn": {
-			"version": "8.12.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-			"integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"acorn": "bin/acorn"
-			},
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/svelte-eslint-parser/node_modules/acorn-jsx": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"dev": true,
-			"license": "MIT",
-			"peerDependencies": {
-				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-			}
-		},
 		"node_modules/svelte-eslint-parser/node_modules/eslint-scope": {
 			"version": "7.2.2",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
@@ -3895,29 +3652,6 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/svelte-eslint-parser/node_modules/esrecurse": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"estraverse": "^5.2.0"
-			},
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
-		"node_modules/svelte-eslint-parser/node_modules/estraverse": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=4.0"
 			}
 		},
 		"node_modules/svelte-eslint-parser/node_modules/postcss-scss": {
@@ -3971,18 +3705,6 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/svelte/node_modules/acorn": {
-			"version": "8.12.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-			"integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
-			"license": "MIT",
-			"bin": {
-				"acorn": "bin/acorn"
-			},
-			"engines": {
-				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/svelte/node_modules/aria-query": {
@@ -4068,15 +3790,6 @@
 				"@types/estree": "^1.0.0",
 				"estree-walker": "^3.0.0",
 				"is-reference": "^3.0.0"
-			}
-		},
-		"node_modules/svelte/node_modules/source-map-js": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/tabbable": {
@@ -4185,9 +3898,9 @@
 			}
 		},
 		"node_modules/tailwindcss/node_modules/postcss-load-config/node_modules/lilconfig": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.2.tgz",
-			"integrity": "sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+			"integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=14"
@@ -4236,6 +3949,19 @@
 				"node": ">=8.0"
 			}
 		},
+		"node_modules/ts-api-utils": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+			"integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.2.0"
+			}
+		},
 		"node_modules/ts-interface-checker": {
 			"version": "0.1.13",
 			"resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -4248,6 +3974,19 @@
 			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
 			"dev": true,
 			"license": "0BSD"
+		},
+		"node_modules/type-check": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"prelude-ls": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
 		},
 		"node_modules/typescript": {
 			"version": "5.6.2",
@@ -4287,6 +4026,15 @@
 				}
 			}
 		},
+		"node_modules/undici-types": {
+			"version": "6.20.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+			"integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
 		"node_modules/update-browserslist-db": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
@@ -4317,6 +4065,12 @@
 			"peerDependencies": {
 				"browserslist": ">= 4.21.0"
 			}
+		},
+		"node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"license": "MIT"
 		},
 		"node_modules/vite": {
 			"version": "5.4.6",
@@ -4921,9 +4675,9 @@
 			}
 		},
 		"node_modules/yaml": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
-			"integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
+			"integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
 			"license": "ISC",
 			"bin": {
 				"yaml": "bin.mjs"

--- a/beef-config/package.json
+++ b/beef-config/package.json
@@ -21,6 +21,7 @@
 		"@types/estree": "^1.0.6",
 		"@types/json-schema": "^7.0.15",
 		"@types/w3c-web-hid": "^1.0.6",
+		"@types/w3c-web-usb": "^1.0.10",
 		"autoprefixer": "^10.4.20",
 		"bits-ui": "^0.21.16",
 		"eslint": "^9.0.0",
@@ -40,8 +41,11 @@
 	},
 	"type": "module",
 	"dependencies": {
+		"buffer": "^6.0.3",
 		"clsx": "^2.1.1",
+		"eventemitter3": "^5.0.1",
 		"lucide-svelte": "^0.441.0",
+		"nrf-intel-hex": "^1.4.0",
 		"tailwind-merge": "^2.5.2",
 		"tailwind-variants": "^0.2.1"
 	}

--- a/beef-config/src/lib/ConfigScreen.svelte
+++ b/beef-config/src/lib/ConfigScreen.svelte
@@ -1,0 +1,202 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { TriangleAlert } from 'lucide-svelte';
+
+	import { Alert } from '$lib/components/ui/alert';
+	import * as AlertDialog from '$lib/components/ui/alert-dialog/index.js';
+	import AlertDescription from '$lib/components/ui/alert/alert-description.svelte';
+	import AlertTitle from '$lib/components/ui/alert/alert-title.svelte';
+	import { Button } from '$lib/components/ui/button';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import * as Select from '$lib/components/ui/select';
+	import { Separator } from '$lib/components/ui/separator/index.js';
+
+	import InputModes from '$lib/InputModes.svelte';
+	import LightEffectSelect from '$lib/LightEffectSelect.svelte';
+	import SliderInput from '$lib/SliderInput.svelte';
+	import Switch from '$lib/Switch.svelte';
+	import ToolTipLabel from '$lib/ToolTipLabel.svelte';
+
+	import { readConfig, updateConfig, type Config } from '$lib/types/config';
+	import { Command, sendCommand, waitForReconnection } from '$lib/types/hid';
+	import { error } from '$lib/types/state';
+	import { TurntableMode, HsvEnumMapping, BarMode, ControllerType } from '$lib/types/types';
+
+	let config: Config | undefined;
+	let controllerTypeChanged = false;
+
+	onMount(async () => {
+		navigator.hid.addEventListener('disconnect', () => {
+			controllerTypeChanged = false;
+		});
+		try {
+			config = await readConfig();
+		} catch (err) {
+			error.set(`Failed to read config: ${err}`);
+		}
+	});
+
+	// This gets fired twice when first loading config data,
+	// apparently will get fixed in Svelte 5?
+	$: {
+		if (config) {
+			try {
+				updateConfig(config);
+			} catch (err) {
+				error.set(`Failed to update config: ${err}`);
+			}
+		}
+	}
+
+	const ttModeMapping: Record<TurntableMode, HsvEnumMapping> = {
+		[TurntableMode.Static]: new HsvEnumMapping('Static', 'tt_static_hsv'),
+		[TurntableMode.Spin]: new HsvEnumMapping('Spin', 'tt_spin_hsv'),
+		[TurntableMode.Shift]: new HsvEnumMapping('Shift', 'tt_shift_hsv'),
+		[TurntableMode.RainbowStatic]: new HsvEnumMapping('Rainbow Static', 'tt_rainbow_static_hsv'),
+		[TurntableMode.RainbowReactive]: new HsvEnumMapping('Rainbow Reactive', 'tt_rainbow_react_hsv'),
+		[TurntableMode.RainbowSpin]: new HsvEnumMapping('Rainbow Spin', 'tt_rainbow_spin_hsv'),
+		[TurntableMode.Reactive]: new HsvEnumMapping('Reactive', 'tt_react_hsv'),
+		[TurntableMode.Breathing]: new HsvEnumMapping('Breathing', 'tt_breathing_hsv'),
+		[TurntableMode.HID]: new HsvEnumMapping('HID'),
+		[TurntableMode.Off]: new HsvEnumMapping('Off')
+	} as const;
+
+	const barModeMapping: Record<BarMode, HsvEnumMapping> = {
+		[BarMode.KeySpectrumP1]: new HsvEnumMapping('Key Spectrum (P1)'),
+		[BarMode.KeySpectrumP2]: new HsvEnumMapping('Key Spectrum (P2)'),
+		[BarMode.HID]: new HsvEnumMapping('HID'),
+		[BarMode.Off]: new HsvEnumMapping('Off')
+	} as const;
+
+	const controllerTypes = Object.values(ControllerType)
+		.filter((v) => isNaN(Number(v)))
+		.map((_, index) => ({
+			value: index,
+			label: ControllerType[index]
+		}));
+</script>
+
+{#if config}
+	<div class="mb-4">
+		<Label for="controller-type">Controller Mode</Label>
+		<Select.Root
+			selected={{
+				value: config.controller_type,
+				label: ControllerType[config.controller_type]
+			}}
+			onSelectedChange={(value) => {
+				if (config && value) {
+					config.controller_type = value.value;
+					controllerTypeChanged = true;
+				}
+			}}
+		>
+			<Select.Trigger class="w-[180px]">
+				<Select.Value placeholder="Controller mode" />
+			</Select.Trigger>
+			<Select.Content>
+				<Select.Group>
+					{#each controllerTypes as type}
+						<Select.Item value={type.value} label={type.label}>{type.label}</Select.Item>
+					{/each}
+				</Select.Group>
+			</Select.Content>
+		</Select.Root>
+	</div>
+
+	{#if controllerTypeChanged}
+		<Alert class="mb-4">
+			<TriangleAlert class="h-4 w-4" />
+			<AlertTitle>Heads up!</AlertTitle>
+			<AlertDescription
+				>Controller mode changed. Please replug the controller to apply the new mode.</AlertDescription
+			>
+		</Alert>
+	{/if}
+
+	<Separator class="mb-4" />
+
+	{#if config.controller_type === ControllerType.IIDX}
+		<div>
+			<h3 class="mb-2 text-lg font-semibold">IIDX Configuration</h3>
+			<InputModes bind:inputMode={config.iidx_input_mode} />
+			<Switch label="Reverse Turntable" bind:checked={config.reverse_tt} />
+			<div class="mb-4">
+				<ToolTipLabel label="Turntable Deadzone">
+					<p>Only affects digital turntable input</p>
+				</ToolTipLabel>
+				<SliderInput bind:value={config.tt_deadzone} min={1} max={6} id="tt-deadzone" />
+			</div>
+
+			{#if config.version >= 12}
+				<div class="mb-4">
+					<ToolTipLabel label="Turntable Sustain Time">
+						<p>Controls how long in milliseconds the last turntable direction is sustained.</p>
+						<p>
+							It effectively controls how sensitive the digital TT is to when the turntable starts
+							and stops spinning.
+						</p>
+					</ToolTipLabel>
+					<SliderInput bind:value={config.tt_sustain_ms} min={0} max={250} id="tt-sustain-ms" />
+				</div>
+			{/if}
+
+			<div class="mb-4">
+				<Label for="tt-ratio">Turntable Sensitivity</Label>
+				<!-- We store TT ratio but present it as TT sensitivity, so invert the range -->
+				<SliderInput bind:value={config.tt_ratio} min={1} max={6} id="tt-ratio" reversed={true} />
+			</div>
+			<Switch label="Disable LEDs" bind:checked={config.disable_leds} />
+
+			{#if !config.disable_leds}
+				<LightEffectSelect
+					label="Turntable Effect"
+					bind:config
+					bind:effect={config.tt_effect}
+					modeMapping={ttModeMapping}
+				/>
+
+				<LightEffectSelect
+					label="Light Bar Effect"
+					bind:config
+					bind:effect={config.bar_effect}
+					modeMapping={barModeMapping}
+				/>
+			{/if}
+		</div>
+	{:else if config.controller_type === ControllerType.SDVX}
+		<div>
+			<h3 class="mb-2 text-lg font-semibold">SDVX Configuration</h3>
+			<InputModes bind:inputMode={config.sdvx_input_mode} />
+			<Switch label="Disable LEDs" bind:checked={config.disable_leds} />
+		</div>
+	{/if}
+
+	<Separator class="mb-4" />
+
+	<div class="mt-4">
+		<AlertDialog.Root closeOnOutsideClick={true}>
+			<AlertDialog.Trigger asChild let:builder>
+				<Button builders={[builder]} variant="destructive">Reset Config</Button>
+			</AlertDialog.Trigger>
+			<AlertDialog.Content>
+				<AlertDialog.Header>
+					<AlertDialog.Title>Are you sure?</AlertDialog.Title>
+					<AlertDialog.Description>
+						This action cannot be undone. This will reset all settings to their default values and
+						the controller will disconnect.
+					</AlertDialog.Description>
+				</AlertDialog.Header>
+				<AlertDialog.Footer>
+					<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+					<AlertDialog.Action
+						on:click={async () => {
+							await sendCommand(Command.ResetConfig);
+							await waitForReconnection();
+						}}>Continue</AlertDialog.Action
+					>
+				</AlertDialog.Footer>
+			</AlertDialog.Content>
+		</AlertDialog.Root>
+	</div>
+{/if}

--- a/beef-config/src/lib/FirmwareScreen.svelte
+++ b/beef-config/src/lib/FirmwareScreen.svelte
@@ -1,0 +1,135 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import MemoryMap from 'nrf-intel-hex';
+
+	import { Button } from '$lib/components/ui/button';
+	import { Label } from '$lib/components/ui/label';
+	import { Input } from '$lib/components/ui/input';
+	import Progress from '$lib/components/ui/progress/progress.svelte';
+
+	import { ATMEL_MAX_TRANSFER_SIZE, DfuDevice } from '$lib/types/dfu';
+	import { Command, readCommitHash, sendCommand, waitForReconnection } from '$lib/types/hid';
+	import { onDisconnect, error, disableConfigTab } from '$lib/types/state';
+
+	const Stage = {
+		Standby: 'standby',
+		Flashing: 'flashing',
+		Finished: 'finished'
+	};
+
+	let commitHash: string;
+	let dfuDevice: DfuDevice | undefined;
+	let firmwareData: MemoryMap;
+	let message = "Ready";
+	let progress = 0;
+	let stage = Stage.Standby;
+
+	onMount(async () => {
+		try {
+			commitHash = await readCommitHash();
+		} catch (err) {
+			error.set(`Error reading commit hash: ${err}`);
+		}
+	});
+
+	async function rebootDevice(): Promise<void> {
+		navigator.hid.removeEventListener('disconnect', onDisconnect);
+		disableConfigTab.set(true);
+		await sendCommand(Command.Bootloader);
+		stage = Stage.Flashing;
+		await connectToDfuDevice();
+	}
+
+	async function connectToDfuDevice(): Promise<void> {
+		try {
+			const dev = await DfuDevice.connect();
+			if (dev === null) {
+				return;
+			}
+			dfuDevice = dev;
+			dfuDevice.on('message', (value) => {
+				message = value;
+			});
+			dfuDevice.on('progress', (value) => {
+				progress = value;
+			});
+
+			navigator.usb.addEventListener('disconnect', onDisconnect);
+		} catch (err) {
+			error.set(`Error connecting to bootloader: ${err}`);
+			throw err;
+		}
+	}
+
+	function parseFirmwareFile(event: Event): void {
+		const target = event.target as HTMLInputElement;
+		const file = target.files?.[0];
+
+		if (file) {
+			const reader = new FileReader();
+
+			// Read the file as text
+			reader.readAsText(file);
+
+			// When the file is read, update the fileContent variable
+			reader.onload = () => {
+				const data = reader.result as string;
+				firmwareData = MemoryMap.fromHex(data, ATMEL_MAX_TRANSFER_SIZE);
+			};
+
+			// Handle errors
+			reader.onerror = () => {
+				error.set('Error reading firmware file');
+			};
+		}
+	}
+
+	async function flashFirmware(): Promise<void> {
+		try {
+			await dfuDevice!.downloadFirmware(firmwareData);
+		} catch (err) {
+			error.set(`Error flashing firmware: ${err}`);
+			throw err;
+		}
+
+		stage = Stage.Finished;
+	}
+
+	async function finishFlashing(): Promise<void> {
+		navigator.usb.removeEventListener('disconnect', onDisconnect);
+		await dfuDevice!.startApplication();
+		await dfuDevice!.device.close();
+		await waitForReconnection();
+	}
+</script>
+
+{#if stage == Stage.Standby}
+	<h3 class="mb-2 text-lg font-semibold">Firmware Commit: <code>0x{commitHash}</code></h3>
+
+	<Button on:click={rebootDevice} class="mb-4">Start Firmware Flash</Button>
+{:else if stage == Stage.Flashing}
+	{#if !dfuDevice}
+		<Button on:click={connectToDfuDevice} class="mb-4">Connect to Bootloader</Button>
+		<Button on:click={onDisconnect} class="mb-4" variant="destructive">Cancel</Button>
+	{:else}
+		<h3 class="mb-2 text-lg font-semibold">Connected to bootloader</h3>
+
+		<div class="mb-4 grid w-full max-w-sm items-center gap-1.5">
+			<Label for="fw">Select Firmware to Flash</Label>
+			<Input name="fw" type="file" accept=".hex" on:change={parseFirmwareFile} />
+		</div>
+
+		{#if firmwareData}
+			<Button on:click={flashFirmware} class="mb-4">Flash Firmware</Button>
+			<Button on:click={finishFlashing} class="mb-4" variant="destructive">Cancel</Button>
+
+			<h3 class="mb-2 text-lg font-semibold">{message}</h3>
+			<Progress value={progress} max={1} class="w-full" />
+		{:else}
+			<Button on:click={finishFlashing} class="mb-4" variant="destructive">Cancel</Button>
+		{/if}
+	{/if}
+{:else if stage == Stage.Finished}
+	<h3 class="mb-2 text-lg font-semibold">Firmware flashed successfully</h3>
+	<Button on:click={finishFlashing} class="mb-4">Exit</Button>
+{/if}

--- a/beef-config/src/lib/LightEffectSelect.svelte
+++ b/beef-config/src/lib/LightEffectSelect.svelte
@@ -1,17 +1,17 @@
-<script lang="ts" extends generics="T extends TurntableMode | BarMode">
+<script lang="ts" generics="T extends TurntableMode | BarMode">
 	import { Label } from '$lib/components/ui/label';
 	import * as Select from '$lib/components/ui/select';
 
 	import ColorPicker from '$lib/ColorPicker.svelte';
 	import type { Config } from '$lib/types/config';
-	import type { BarMode, EnumMapping, TurntableMode } from '$lib/types/types';
+	import type { BarMode, HsvEnumMapping, TurntableMode } from '$lib/types/types';
 
 	export let label: string;
 	export let config: Config;
 	export let effect: T;
-	export let modeMapping: Record<T, EnumMapping>;
+	export let modeMapping: Record<T, HsvEnumMapping>;
 
-	const modeMappingIter = Object.entries<EnumMapping>(modeMapping);
+	const modeMappingIter = Object.entries<HsvEnumMapping>(modeMapping);
 </script>
 
 <div class="mb-4">

--- a/beef-config/src/lib/components/ui/progress/index.ts
+++ b/beef-config/src/lib/components/ui/progress/index.ts
@@ -1,0 +1,7 @@
+import Root from "./progress.svelte";
+
+export {
+	Root,
+	//
+	Root as Progress,
+};

--- a/beef-config/src/lib/components/ui/progress/progress.svelte
+++ b/beef-config/src/lib/components/ui/progress/progress.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { Progress as ProgressPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	type $$Props = ProgressPrimitive.Props;
+
+	let className: $$Props["class"] = undefined;
+	export let max: $$Props["max"] = 100;
+	export let value: $$Props["value"] = undefined;
+	export { className as class };
+</script>
+
+<ProgressPrimitive.Root
+	class={cn("bg-secondary relative h-4 w-full overflow-hidden rounded-full", className)}
+	{...$$restProps}
+>
+	<div
+		class="bg-primary h-full w-full flex-1 transition-all"
+		style={`transform: translateX(-${100 - (100 * (value ?? 0)) / (max ?? 1)}%)`}
+	></div>
+</ProgressPrimitive.Root>

--- a/beef-config/src/lib/components/ui/tabs/index.ts
+++ b/beef-config/src/lib/components/ui/tabs/index.ts
@@ -1,0 +1,18 @@
+import { Tabs as TabsPrimitive } from "bits-ui";
+import Content from "./tabs-content.svelte";
+import List from "./tabs-list.svelte";
+import Trigger from "./tabs-trigger.svelte";
+
+const Root = TabsPrimitive.Root;
+
+export {
+	Root,
+	Content,
+	List,
+	Trigger,
+	//
+	Root as Tabs,
+	Content as TabsContent,
+	List as TabsList,
+	Trigger as TabsTrigger,
+};

--- a/beef-config/src/lib/components/ui/tabs/tabs-content.svelte
+++ b/beef-config/src/lib/components/ui/tabs/tabs-content.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { Tabs as TabsPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	type $$Props = TabsPrimitive.ContentProps;
+
+	let className: $$Props["class"] = undefined;
+	export let value: $$Props["value"];
+	export { className as class };
+</script>
+
+<TabsPrimitive.Content
+	class={cn(
+		"ring-offset-background focus-visible:ring-ring mt-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
+		className
+	)}
+	{value}
+	{...$$restProps}
+>
+	<slot />
+</TabsPrimitive.Content>

--- a/beef-config/src/lib/components/ui/tabs/tabs-list.svelte
+++ b/beef-config/src/lib/components/ui/tabs/tabs-list.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { Tabs as TabsPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	type $$Props = TabsPrimitive.ListProps;
+
+	let className: $$Props["class"] = undefined;
+	export { className as class };
+</script>
+
+<TabsPrimitive.List
+	class={cn(
+		"bg-muted text-muted-foreground inline-flex h-10 items-center justify-center rounded-md p-1",
+		className
+	)}
+	{...$$restProps}
+>
+	<slot />
+</TabsPrimitive.List>

--- a/beef-config/src/lib/components/ui/tabs/tabs-trigger.svelte
+++ b/beef-config/src/lib/components/ui/tabs/tabs-trigger.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { Tabs as TabsPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	type $$Props = TabsPrimitive.TriggerProps;
+	type $$Events = TabsPrimitive.TriggerEvents;
+
+	let className: $$Props["class"] = undefined;
+	export let value: $$Props["value"];
+	export { className as class };
+</script>
+
+<TabsPrimitive.Trigger
+	class={cn(
+		"ring-offset-background focus-visible:ring-ring data-[state=active]:bg-background data-[state=active]:text-foreground inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm",
+		className
+	)}
+	{value}
+	{...$$restProps}
+	on:click
+>
+	<slot />
+</TabsPrimitive.Trigger>

--- a/beef-config/src/lib/types/config.ts
+++ b/beef-config/src/lib/types/config.ts
@@ -1,4 +1,6 @@
+import { get } from 'svelte/store';
 import { ReportId } from '$lib/types/hid';
+import { device } from '$lib/types/state';
 import { TurntableMode, BarMode, ControllerType, InputMode, Hsv } from '$lib/types/types';
 
 export class Config {
@@ -82,7 +84,12 @@ export class Config {
 
 const packetSize = 64;
 
-export async function readConfig(dev: HIDDevice): Promise<Config> {
+export async function readConfig(): Promise<Config> {
+  const dev = get(device);
+  if (!dev) {
+    throw new Error('Device not connected');
+  }
+
   try {
     const result = await dev.receiveFeatureReport(ReportId.Config);
     const configData = new DataView(result.buffer.slice(1)); // Skip report id
@@ -98,7 +105,12 @@ export async function readConfig(dev: HIDDevice): Promise<Config> {
   }
 }
 
-export async function updateConfig(dev: HIDDevice, config: Config): Promise<void> {
+export async function updateConfig(config: Config): Promise<void> {
+  const dev = get(device);
+  if (!dev) {
+    throw new Error('Device not connected');
+  }
+
   try {
     const configBuffer = new ArrayBuffer(packetSize);
     const configView = new DataView(configBuffer);

--- a/beef-config/src/lib/types/dfu.ts
+++ b/beef-config/src/lib/types/dfu.ts
@@ -1,0 +1,298 @@
+// Thanks to dfu-programmer for being the reference implementation
+
+import { EventEmitter } from "eventemitter3";
+import { Buffer } from "buffer";
+import type MemoryMap from "nrf-intel-hex";
+
+// DFU Constants from Datasheet
+const DFU_VID_AT90USB1286 = 0x03eb;
+const DFU_PID_AT90USB1286 = 0x2ffb;
+const DFU_INTERFACE = 0;
+
+const ATMEL_CONTROL_BLOCK_SIZE = 32;
+export const ATMEL_MAX_TRANSFER_SIZE = 0x400;
+
+// DFU Class-Specific Requests (Table 4-1)
+enum DfuRequest {
+  DETACH = 0,
+  DNLOAD = 1,
+  UPLOAD = 2,
+  GETSTATUS = 3,
+  CLRSTATUS = 4,
+  GETSTATE = 5,
+  ABORT = 6,
+}
+
+enum DfuCommand {
+  PROG_START = 0x01,
+  ERASE = 0x04,
+  READ_CONFIG = 0x05,
+  START_APP = 0x03,
+}
+
+enum DfuMemoryUnit {
+  FLASH = 0,
+  EEPROM = 1,
+}
+
+// DFU Status Codes (Table 4-5)
+enum DfuStatus {
+  OK = 0x00,
+  errWRITE = 0x03,
+  // ... Add other status codes as needed
+}
+
+// DFU State Codes (Table 4-6)
+enum DfuState {
+  appIDLE = 0,
+  appDETACH = 1,
+  dfuIDLE = 2,
+  dfuDNLOAD_SYNC = 3,
+  dfuDNBUSY = 4,
+  // ... Add other states as needed
+}
+
+interface DfuStatusResponse {
+  status: DfuStatus;
+  pollTimeout: number;
+  state: DfuState;
+  string: number; // String index
+}
+
+export class DfuDevice extends EventEmitter {
+  private _device: USBDevice;
+  private interfaceNumber: number;
+  private transaction: number = 0;
+
+  private constructor(device: USBDevice, interfaceNumber: number) {
+    super();
+    this._device = device;
+    this.interfaceNumber = interfaceNumber;
+  }
+
+  public get device() {
+    return this._device;
+  }
+
+  static async connect(): Promise<DfuDevice | null> {
+    try {
+      const device = await navigator.usb.requestDevice({
+        filters: [{ vendorId: DFU_VID_AT90USB1286, productId: DFU_PID_AT90USB1286 }]
+      });
+
+      await device.open();
+      await device.selectConfiguration(1);
+      await device.claimInterface(DFU_INTERFACE);
+
+      return new DfuDevice(device, DFU_INTERFACE);
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'NotFoundError') {
+        return null;
+      }
+      throw err;
+    }
+  }
+
+  private async sendDfuCommandOut(
+    request: DfuRequest,
+    value: number,
+    data?: Uint8Array
+  ): Promise<void> {
+    const result = await this._device.controlTransferOut({
+      requestType: 'class',
+      recipient: 'interface',
+      request,
+      value,
+      index: this.interfaceNumber,
+    }, data);
+    if (result.status !== 'ok') {
+      throw new Error(`DFU command ${request} failed`);
+    }
+  }
+
+  private async sendDfuCommandIn(
+    request: DfuRequest,
+    value: number,
+    length: number
+  ): Promise<DataView> {
+    const result = await this._device.controlTransferIn({
+      requestType: 'class',
+      recipient: 'interface',
+      request,
+      value,
+      index: this.interfaceNumber,
+    }, length);
+    if (result.status !== 'ok') {
+      throw new Error(`DFU command ${request} failed`);
+    }
+
+    return new DataView(result.data!.buffer);
+  }
+
+  private async dfuDownload(data: Uint8Array): Promise<void> {
+    await this.sendDfuCommandOut(DfuRequest.DNLOAD, this.transaction++, data);
+    await this.waitForState(DfuState.dfuIDLE);
+  }
+
+  private async getStatus(): Promise<DfuStatusResponse> {
+    const view = await this.sendDfuCommandIn(DfuRequest.GETSTATUS, 0, 6);
+    return {
+      status: view.getUint8(0),
+      pollTimeout: view.getUint32(1, true) & 0x00ffffff,
+      state: view.getUint8(4),
+      string: view.getUint8(5),
+    };
+  }
+
+  async waitForState(state: DfuState): Promise<void> {
+    let status: DfuStatusResponse;
+    do {
+      status = await this.getStatus();
+      if (status.status !== DfuStatus.OK) {
+        throw new Error('DFU status error: ' + status.status);
+      }
+      await new Promise(resolve => setTimeout(resolve, status.pollTimeout));
+    } while (status.state !== state);
+  }
+
+  private async abort(): Promise<void> {
+    console.log('Aborting');
+    await this.sendDfuCommandOut(DfuRequest.ABORT, 0);
+    await this.waitForState(DfuState.dfuIDLE);
+  }
+
+  private async eraseFullChip(): Promise<void> {
+    console.log('Erasing full chip');
+    this.emit('message', 'Erasing chip...');
+    const eraseCmd = new Uint8Array([0x04, 0x00, 0xff]);
+    await this.dfuDownload(eraseCmd);
+  }
+
+  private async selectMemoryUnit(unit: DfuMemoryUnit): Promise<void> {
+    console.log('Selecting memory unit:', unit);
+    const selectCmd = new Uint8Array([0x06, 0x03, 0x00, (0xff & unit)]);
+    await this.dfuDownload(selectCmd);
+  }
+
+  async downloadFirmware(firmware: MemoryMap): Promise<void> {
+    await this.abort(); // Necessary to put DFU state to dfuIDLE I think?
+    await this.eraseFullChip();
+    await this.selectMemoryUnit(DfuMemoryUnit.FLASH);
+
+    this.emit('message', 'Flashing');
+    const fixedFirmware = convertMapToFixedLength(firmware, ATMEL_MAX_TRANSFER_SIZE);
+    let i = 0;
+    for await (const [address, segment] of fixedFirmware) {
+      const progress = i++ / firmware.size;
+      console.log('Progress:', progress);
+      this.emit('progress', progress);
+
+      const image = createDfuImage(segment, address);
+      await this.dfuDownload(image);
+    }
+
+    // Send final zero-length packet
+    console.log('Sending final packet');
+    this.emit('progress', 1);
+    await this.dfuDownload(new Uint8Array(0));
+    this.emit('message', 'Finished');
+  }
+
+  async startApplication(): Promise<void> {
+    console.log('Starting application');
+    this.emit('message', 'Starting application');
+    const startCmd = new Uint8Array([0x04, 0x03, 0x00]);
+    await this.sendDfuCommandOut(DfuRequest.DNLOAD, this.transaction++, startCmd);
+    try {
+      await this.getStatus();
+    } catch (_) {
+      // For some reason we need to send a GETSTATUS request to get the DFU to actually restart
+      // This will raise an exception, so just ignore it
+    }
+  }
+}
+
+// Helper function to create DFU-compatible firmware with suffix
+function createDfuImage(segment: Uint8Array, start: number): Uint8Array {
+  const header = Buffer.alloc(ATMEL_CONTROL_BLOCK_SIZE);
+
+  header.writeUInt8(DfuCommand.PROG_START, 0);
+
+  // Indicates if the segment is for flash or EEPROM
+  header.writeUInt8(0, 1);
+
+  header.writeUInt16BE(0xffff & start, 2);
+  header.writeUInt16BE(0xffff & (start + segment.length - 1), 4);
+
+  const suffixLength = 16;
+  const suffix = Buffer.alloc(suffixLength);
+
+  // CRC of entire segment including header and suffix
+  // Unused?
+  suffix.writeUInt32BE(0, 0);
+
+  suffix.writeUInt8(suffixLength, 4);
+
+  // DFU Signature
+  suffix.write('DFU', 5);
+
+  // BCD DFU specification number (1.1)
+  suffix.writeUInt16BE(0x0110, 8);
+
+  // Vendor ID
+  suffix.writeUInt16BE(0xffff, 10);
+
+  // Product ID
+  suffix.writeUInt16BE(0xffff, 12);
+
+  // BCD Firmware release number
+  suffix.writeUInt16BE(0xffff, 14);
+
+  return Buffer.concat([header, segment, suffix]);
+}
+
+// Ideally this wouldn't be required, but there's a bug in the nrf-intel-hex library
+// and how it handles the chunking of the firmware with variable length segments.
+// Basically, it doesn't seem to be able to handle segments that aren't a multiple of 16 bytes correctly
+// and will cause some segments to exceed their supposed max block size.
+// Thus, we do a third pass to make sure each segment fits into the max block size,
+// and to shift any overflows into the next block.
+// I'm not sure if this is actually a bug in regards to the Intel Hex spec,
+// but it causes issues with the Atmel DFU protocol.
+function convertMapToFixedLength(inputMap: MemoryMap, fixedLength: number) {
+  const outputMap = new Map();
+  let currentChunk = new Uint8Array(fixedLength);
+  let offset = 0;       // current write index in the chunk
+  let address = 0;   // key for the output map
+
+  // Iterate over the input map in insertion order.
+  for (const [_, arr] of inputMap) {
+    for (let i = 0; i < arr.length; i++) {
+      // Write the byte into the current chunk.
+      currentChunk[offset] = arr[i];
+      offset++;
+
+      // If we have filled the chunk, add it to the output map
+      if (offset === fixedLength) {
+        outputMap.set(address, currentChunk);
+        // Move to the next address.
+        address += fixedLength;
+        // Create a new chunk and reset offset.
+        currentChunk = new Uint8Array(fixedLength);
+        offset = 0;
+      }
+    }
+  }
+
+  // If there are remaining bytes that didn't fill a complete chunk,
+  // we pad the rest with 0xff.
+  if (offset > 0) {
+    currentChunk.fill(0xff, offset);
+    // Pad to the nearest 16th byte
+    offset += 16 - (16 % offset);
+    currentChunk = currentChunk.slice(0, offset);
+    outputMap.set(address, currentChunk);
+  }
+
+  return outputMap;
+}

--- a/beef-config/src/lib/types/dfu.ts
+++ b/beef-config/src/lib/types/dfu.ts
@@ -12,7 +12,7 @@ const DFU_INTERFACE = 0;
 const ATMEL_CONTROL_BLOCK_SIZE = 32;
 export const ATMEL_MAX_TRANSFER_SIZE = 0x400;
 
-// DFU Class-Specific Requests (Table 4-1)
+// DFU Class-Specific Requests
 enum DfuRequest {
   DETACH = 0,
   DNLOAD = 1,
@@ -20,36 +20,34 @@ enum DfuRequest {
   GETSTATUS = 3,
   CLRSTATUS = 4,
   GETSTATE = 5,
-  ABORT = 6,
+  ABORT = 6
 }
 
 enum DfuCommand {
   PROG_START = 0x01,
   ERASE = 0x04,
   READ_CONFIG = 0x05,
-  START_APP = 0x03,
+  START_APP = 0x03
 }
 
 enum DfuMemoryUnit {
   FLASH = 0,
-  EEPROM = 1,
+  EEPROM = 1
 }
 
-// DFU Status Codes (Table 4-5)
+// DFU Status Codes
 enum DfuStatus {
   OK = 0x00,
-  errWRITE = 0x03,
-  // ... Add other status codes as needed
+  errWRITE = 0x03
 }
 
-// DFU State Codes (Table 4-6)
+// DFU State Codes
 enum DfuState {
   appIDLE = 0,
   appDETACH = 1,
   dfuIDLE = 2,
   dfuDNLOAD_SYNC = 3,
-  dfuDNBUSY = 4,
-  // ... Add other states as needed
+  dfuDNBUSY = 4
 }
 
 interface DfuStatusResponse {

--- a/beef-config/src/lib/types/state.ts
+++ b/beef-config/src/lib/types/state.ts
@@ -1,0 +1,29 @@
+import { detectDevice } from "$lib/types/hid";
+import { get, writable } from "svelte/store";
+
+export const disableConfigTab = writable(false);
+export const device = writable<HIDDevice | undefined>(undefined);
+export const error = writable<string | undefined>(undefined);
+
+export async function onDisconnect(): Promise<void> {
+  await get(device)?.close();
+  disableConfigTab.set(false);
+  device.set(undefined);
+  error.set(undefined);
+}
+
+export async function connectDevice(): Promise<void> {
+  try {
+    const dev = await detectDevice();
+    if (dev === null) {
+      return;
+    }
+    device.set(dev);
+    navigator.hid.addEventListener('disconnect', onDisconnect);
+    error.set(undefined);
+  } catch (err) {
+    await onDisconnect();
+    error.set(`Error communicating with device: ${err}`);
+    throw err;
+  }
+}

--- a/beef-config/src/lib/types/types.ts
+++ b/beef-config/src/lib/types/types.ts
@@ -53,7 +53,7 @@ export class Hsv {
   }
 }
 
-export class EnumMapping {
+export class HsvEnumMapping {
   displayName: string;
   hsvField?: keyof Config;
 

--- a/beef-config/src/routes/+page.svelte
+++ b/beef-config/src/routes/+page.svelte
@@ -1,135 +1,33 @@
 <script lang="ts">
-	import { onDestroy, onMount } from 'svelte';
-	import { TriangleAlert } from 'lucide-svelte';
+	import { onMount } from 'svelte';
 
 	import { Alert } from '$lib/components/ui/alert';
 	import AlertDescription from '$lib/components/ui/alert/alert-description.svelte';
-	import * as AlertDialog from '$lib/components/ui/alert-dialog/index.js';
 	import AlertTitle from '$lib/components/ui/alert/alert-title.svelte';
 	import { Button } from '$lib/components/ui/button';
-	import { Label } from '$lib/components/ui/label/index.js';
-	import * as Select from '$lib/components/ui/select';
-	import { Separator } from '$lib/components/ui/separator/index.js';
-	import { Slider } from '$lib/components/ui/slider';
 	import { Skeleton } from '$lib/components/ui/skeleton/index.js';
+	import * as Tabs from '$lib/components/ui/tabs';
 
-	import InputModes from '$lib/InputModes.svelte';
-	import LightEffectSelect from '$lib/LightEffectSelect.svelte';
-	import SliderInput from '$lib/SliderInput.svelte';
-	import Switch from '$lib/Switch.svelte';
-	import ToolTipLabel from '$lib/ToolTipLabel.svelte';
-	import { Config, readConfig, updateConfig } from '$lib/types/config';
-	import { ReportId, Command, detectDevice } from '$lib/types/hid';
-	import { TurntableMode, BarMode, ControllerType, EnumMapping } from '$lib/types/types';
+	import ConfigScreen from '$lib/ConfigScreen.svelte';
+	import FirmwareScreen from '$lib/FirmwareScreen.svelte';
 
-	let device: HIDDevice | null = null;
-	let config: Config | null = null;
-	let commitHash: string | null = null;
-	let error: string | null = null;
-	let isWebHIDSupported = false;
+	import { connectDevice, disableConfigTab, device, error } from '$lib/types/state';
+
+	const Tab = {
+		Config: 'config',
+		Firmware: 'dfu'
+	} as const;
+
+	let browserSupported = false;
 	let loading = true;
-	let controllerTypeChanged = false;
-
-	const ttModeMapping: Record<TurntableMode, EnumMapping> = {
-		[TurntableMode.Static]: new EnumMapping('Static', 'tt_static_hsv'),
-		[TurntableMode.Spin]: new EnumMapping('Spin', 'tt_spin_hsv'),
-		[TurntableMode.Shift]: new EnumMapping('Shift', 'tt_shift_hsv'),
-		[TurntableMode.RainbowStatic]: new EnumMapping('Rainbow Static', 'tt_rainbow_static_hsv'),
-		[TurntableMode.RainbowReactive]: new EnumMapping('Rainbow Reactive', 'tt_rainbow_react_hsv'),
-		[TurntableMode.RainbowSpin]: new EnumMapping('Rainbow Spin', 'tt_rainbow_spin_hsv'),
-		[TurntableMode.Reactive]: new EnumMapping('Reactive', 'tt_react_hsv'),
-		[TurntableMode.Breathing]: new EnumMapping('Breathing', 'tt_breathing_hsv'),
-		[TurntableMode.HID]: new EnumMapping('HID'),
-		[TurntableMode.Off]: new EnumMapping('Off')
-	} as const;
-
-	const barModeMapping: Record<BarMode, EnumMapping> = {
-		[BarMode.KeySpectrumP1]: new EnumMapping('Key Spectrum (P1)'),
-		[BarMode.KeySpectrumP2]: new EnumMapping('Key Spectrum (P2)'),
-		[BarMode.HID]: new EnumMapping('HID'),
-		[BarMode.Off]: new EnumMapping('Off')
-	} as const;
-
-	export const controllerTypes = Object.values(ControllerType)
-		.filter((v) => isNaN(Number(v)))
-		.map((_, index) => ({
-			value: index,
-			label: ControllerType[index]
-		}));
 
 	onMount(() => {
-		checkWebHIDSupport();
+		checkBrowserSupport();
 		loading = false;
 	});
 
-	onDestroy(onDisconnect);
-
-	// This gets fired twice when first loading config data,
-	// apparently will get fixed in Svelte 5?
-	$: if (device && config) {
-		try {
-			updateConfig(device, config);
-		} catch (err) {
-			error = `Failed to update config: ${err}`;
-		}
-	}
-
-	function checkWebHIDSupport(): void {
-		if ('hid' in navigator) {
-			isWebHIDSupported = true;
-		} else {
-			error =
-				'WebHID is not supported in this browser. Please use a compatible browser like Chrome or Edge.';
-		}
-	}
-
-	async function onDisconnect(): Promise<void> {
-		await device?.close();
-		device = null;
-		config = null;
-		commitHash = null;
-		error = null;
-	}
-
-	async function connectDevice(): Promise<void> {
-		error = null;
-		try {
-			device = await detectDevice();
-			await readCommitHash(device);
-			config = await readConfig(device);
-			navigator.hid.addEventListener('disconnect', onDisconnect);
-		} catch (err) {
-			await onDisconnect();
-			error = `Error communicating with device: ${err}`;
-			return Promise.reject(err);
-		}
-	}
-
-	async function readCommitHash(dev: HIDDevice): Promise<void> {
-		try {
-			const result = await dev.receiveFeatureReport(ReportId.FirmwareVersion);
-			const hashData = new DataView(result.buffer.slice(1)); // Skip report id
-			commitHash = hashData.getUint32(0, true).toString(16).padStart(8, '0');
-		} catch (err) {
-			err = new Error('Failed to read commit hash', { cause: err });
-			return Promise.reject(err);
-		}
-	}
-
-	async function waitForReconnection(): Promise<void> {
-		await onDisconnect().then(connectDevice);
-	}
-
-	async function sendCommand(device: HIDDevice, command: Command): Promise<void> {
-		try {
-			const commandData = new Uint8Array([command]);
-			await device.sendFeatureReport(ReportId.Command, commandData).catch((err) => {
-				return Promise.reject(new Error('Failed to send command', { cause: err }));
-			});
-		} catch (err) {
-			error = `Failed to send command: ${err}`;
-			return Promise.reject(err);
-		}
+	function checkBrowserSupport(): void {
+		browserSupported = 'hid' in navigator && 'usb' in navigator;
 	}
 </script>
 
@@ -138,163 +36,34 @@
 
 	{#if loading}
 		<Skeleton class="h-10" />
-	{:else if !isWebHIDSupported}
+	{:else if !browserSupported}
 		<Alert variant="destructive">
 			<AlertTitle>Browser Not Supported</AlertTitle>
 			<AlertDescription>
-				WebHID is not supported in this browser. Please use a compatible browser like Chrome or
-				Edge.
+				WebHID/WebUSB is not supported in this browser. Please use a compatible browser like Chrome
+				or Edge.
 			</AlertDescription>
 		</Alert>
 	{:else}
-		{#if !device}
+		{#if !$device}
 			<Button on:click={connectDevice} class="mb-4">Connect Device</Button>
-		{:else if config}
-			<div class="mb-4">
-				<Label for="controller-type">Controller Mode</Label>
-				<Select.Root
-					selected={{
-						value: config.controller_type,
-						label: ControllerType[config.controller_type]
-					}}
-					onSelectedChange={(value) => {
-						if (config && value) {
-							config.controller_type = value.value;
-							controllerTypeChanged = true;
-						}
-					}}
-				>
-					<Select.Trigger class="w-[180px]">
-						<Select.Value placeholder="Controller mode" />
-					</Select.Trigger>
-					<Select.Content>
-						<Select.Group>
-							{#each controllerTypes as type}
-								<Select.Item value={type.value} label={type.label}>{type.label}</Select.Item>
-							{/each}
-						</Select.Group>
-					</Select.Content>
-				</Select.Root>
-			</div>
-
-			{#if controllerTypeChanged}
-				<Alert class="mb-4">
-					<TriangleAlert class="h-4 w-4" />
-					<AlertTitle>Heads up!</AlertTitle>
-					<AlertDescription
-						>Controller mode changed. Please replug the controller to apply the new mode.</AlertDescription
+		{:else}
+			<Tabs.Root value={Tab.Config}>
+				<Tabs.List class="flex w-full flex-row justify-center">
+					<Tabs.Trigger value={Tab.Config} disabled={$disableConfigTab} class="grow"
+						>Config</Tabs.Trigger
 					>
-				</Alert>
-			{/if}
-
-			<h3 class="mb-2 text-lg font-semibold">Firmware Commit: <code>0x{commitHash}</code></h3>
-
-			<Separator class="mb-4" />
-
-			{#if config.controller_type === ControllerType.IIDX}
-				<div>
-					<h3 class="mb-2 text-lg font-semibold">IIDX Configuration</h3>
-					<InputModes bind:inputMode={config.iidx_input_mode} />
-					<Switch label="Reverse Turntable" bind:checked={config.reverse_tt} />
-					<div class="mb-4">
-						<ToolTipLabel label="Turntable Deadzone">
-							<p>Only affects digital turntable input</p>
-						</ToolTipLabel>
-						<SliderInput bind:value={config.tt_deadzone} min={1} max={6} id="tt-deadzone" />
-					</div>
-
-					{#if config.version >= 12}
-						<div class="mb-4">
-							<ToolTipLabel label="Turntable Sustain Time">
-								<p>Controls how long in milliseconds the last turntable direction is sustained.</p>
-								<p>
-									It effectively controls how sensitive the digital TT is to when the turntable
-									starts and stops spinning.
-								</p>
-							</ToolTipLabel>
-							<SliderInput bind:value={config.tt_sustain_ms} min={0} max={250} id="tt-sustain-ms" />
-						</div>
-					{/if}
-
-					<div class="mb-4">
-						<Label for="tt-ratio">Turntable Sensitivity</Label>
-						<!-- We store TT ratio but present it as TT sensitivity, so invert the range -->
-						<SliderInput
-							bind:value={config.tt_ratio}
-							min={1}
-							max={6}
-							id="tt-ratio"
-							reversed={true}
-						/>
-					</div>
-					<Switch label="Disable LEDs" bind:checked={config.disable_leds} />
-
-					{#if !config.disable_leds}
-						<LightEffectSelect
-							label="Turntable Effect"
-							bind:config
-							bind:effect={config.tt_effect}
-							modeMapping={ttModeMapping}
-						/>
-
-						<LightEffectSelect
-							label="Light Bar Effect"
-							bind:config
-							bind:effect={config.bar_effect}
-							modeMapping={barModeMapping}
-						/>
-					{/if}
-				</div>
-			{:else if config.controller_type === ControllerType.SDVX}
-				<div>
-					<h3 class="mb-2 text-lg font-semibold">SDVX Configuration</h3>
-					<InputModes bind:inputMode={config.sdvx_input_mode} />
-					<Switch label="Disable LEDs" bind:checked={config.disable_leds} />
-				</div>
-			{/if}
-
-			<Separator class="mb-4" />
-
-			<div class="mt-4">
-				<Button
-					on:click={async () => {
-						if (device) {
-							await sendCommand(device, Command.Bootloader);
-						}
-					}}
-					class="mr-2">Enter Bootloader</Button
-				>
-				<AlertDialog.Root closeOnOutsideClick={true}>
-					<AlertDialog.Trigger asChild let:builder>
-						<Button builders={[builder]} variant="destructive">Reset Config</Button>
-					</AlertDialog.Trigger>
-					<AlertDialog.Content>
-						<AlertDialog.Header>
-							<AlertDialog.Title>Are you sure?</AlertDialog.Title>
-							<AlertDialog.Description>
-								This action cannot be undone. This will reset all settings to their default values
-								and the controller will disconnect.
-							</AlertDialog.Description>
-						</AlertDialog.Header>
-						<AlertDialog.Footer>
-							<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-							<AlertDialog.Action
-								on:click={async () => {
-									if (device) {
-										await sendCommand(device, Command.ResetConfig).then(waitForReconnection);
-									}
-								}}>Continue</AlertDialog.Action
-							>
-						</AlertDialog.Footer>
-					</AlertDialog.Content>
-				</AlertDialog.Root>
-			</div>
+					<Tabs.Trigger value={Tab.Firmware} class="grow">Firmware</Tabs.Trigger>
+				</Tabs.List>
+				<Tabs.Content value={Tab.Config}><ConfigScreen /></Tabs.Content>
+				<Tabs.Content value={Tab.Firmware}><FirmwareScreen /></Tabs.Content>
+			</Tabs.Root>
 		{/if}
 
-		{#if error}
+		{#if $error}
 			<Alert variant="destructive" class="mb-4">
 				<AlertTitle>Error</AlertTitle>
-				<AlertDescription>{error}</AlertDescription>
+				<AlertDescription>{$error}</AlertDescription>
 			</Alert>
 		{/if}
 	{/if}


### PR DESCRIPTION
Closes #108.

This PR implements the Atmel DFU protocol in TypeScript for our MCU. Intel HEX parsing is provided by the `nrf-intel-hex` library. Comes with a progress bar to let the user know how far along they are with the flashing process.

This has been an on-and-off project for a few months now, so if you have any questions feel free. I can't really remember what I did to put in this description lol.

Thanks to dfu-programmer as serving as the reference implementation, otherwise I imagine this would have been much more painful than it already is. I'm pretty sure there is literally no existing NPM library that supports our MCU for some reason, it's all Arduino stuff or STM MCUs.

Other changes:
* Reorganise web code to reduce prop drilling (use global variables and stores basically)
* Split config HTML into it's own Svelte component
* Rename `EnumMapping` to `HsvEnumMapping`
* Move various HID related functions around for better code organisation
* Update unsupported browser message to mention WebUSB support requirement

Shout out to DeepSeek R1 for generating 90% of the DFU code (with the last 10%, again, taking 90% of the effort lol).

Todo:
- [x] Add a link to the DFU drivers
- [x] Hide buttons while flashing
- [ ] Add a warning to tell users to only flash beef board firmware
- [x] Add a warning to tell users to not disconnect the board while flashing
- [x] Make the progress bar persist after flashing is finished
- [ ] Update README with updated screenshot of web config and new features