### PR TITLE
Add outdated firmware warning to web config

### DIFF
--- a/beef-config/src/lib/ConfigScreen.svelte
+++ b/beef-config/src/lib/ConfigScreen.svelte
@@ -177,30 +177,30 @@
 	{/if}
 
 	<Separator class="mb-4" />
-
-	<div class="mt-4">
-		<AlertDialog.Root closeOnOutsideClick={true}>
-			<AlertDialog.Trigger asChild let:builder>
-				<Button builders={[builder]} variant="destructive">Reset Config</Button>
-			</AlertDialog.Trigger>
-			<AlertDialog.Content>
-				<AlertDialog.Header>
-					<AlertDialog.Title>Are you sure?</AlertDialog.Title>
-					<AlertDialog.Description>
-						This action cannot be undone. This will reset all settings to their default values and
-						the controller will disconnect.
-					</AlertDialog.Description>
-				</AlertDialog.Header>
-				<AlertDialog.Footer>
-					<AlertDialog.Action
-						on:click={async () => {
-							await sendCommand(Command.ResetConfig);
-							await waitForReconnection();
-						}}>Continue</AlertDialog.Action
-					>
-					<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-				</AlertDialog.Footer>
-			</AlertDialog.Content>
-		</AlertDialog.Root>
-	</div>
 {/if}
+
+<div class="mt-4">
+	<AlertDialog.Root closeOnOutsideClick={true}>
+		<AlertDialog.Trigger asChild let:builder>
+			<Button builders={[builder]} variant="destructive">Reset Config</Button>
+		</AlertDialog.Trigger>
+		<AlertDialog.Content>
+			<AlertDialog.Header>
+				<AlertDialog.Title>Are you sure?</AlertDialog.Title>
+				<AlertDialog.Description>
+					This action cannot be undone. This will reset all settings to their default values and
+					the controller will disconnect.
+				</AlertDialog.Description>
+			</AlertDialog.Header>
+			<AlertDialog.Footer>
+				<AlertDialog.Action
+					on:click={async () => {
+						await sendCommand(Command.ResetConfig);
+						await waitForReconnection();
+					}}>Continue</AlertDialog.Action
+				>
+				<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+			</AlertDialog.Footer>
+		</AlertDialog.Content>
+	</AlertDialog.Root>
+</div>

--- a/beef-config/src/lib/ConfigScreen.svelte
+++ b/beef-config/src/lib/ConfigScreen.svelte
@@ -72,6 +72,13 @@
 </script>
 
 {#if config}
+	{#if config.version < 13}
+		<WarningAlert
+			title="Outdated Firmware"
+			description="Your firmware version is too old. Some features may not be available. Please update your firmware to access all features."
+		/>
+	{/if}
+
 	<div class="mb-4">
 		<Label for="controller-type">Controller Mode</Label>
 		<Select.Root

--- a/beef-config/src/lib/WarningAlert.svelte
+++ b/beef-config/src/lib/WarningAlert.svelte
@@ -6,7 +6,7 @@
 
 	export let title: string;
 	export let description: string;
-	export let variant: 'default' | 'destructive' | undefined = 'default';
+	export let variant: 'default' | 'destructive' = 'default';
 </script>
 
 <Alert class="mb-4" {variant}>

--- a/beef-config/src/routes/+page.svelte
+++ b/beef-config/src/routes/+page.svelte
@@ -65,7 +65,7 @@
 		{/if}
 
 		{#if $error}
-			<Alert variant="destructive" class="mb-4">
+			<Alert variant="destructive" class="mt-4">
 				<AlertTitle>Error</AlertTitle>
 				<AlertDescription>{$error}</AlertDescription>
 			</Alert>


### PR DESCRIPTION
Closes #130.

This adds a banner at the top of the config screen to tell the user to upgrade their firmware if it doesn't support new features in the web config.
![warning](https://github.com/user-attachments/assets/d6a2491c-9098-4b78-9be3-734d8310f73f)

I've also made it so that the reset config button is always shown, so users can try resetting their config to fix any read errors.
![config reset](https://github.com/user-attachments/assets/1a8db6a9-8f14-4153-b042-fc23092e5906)

Also fixed the spacing on the error message from the reset config button.

As far the potential bug, it turns out it was because of weird shenanigans from flashing old firmware over a newer one. No fixes needed.