### PR TITLE
Fix digital TT outputs not having correct deadzone while turning, direction being reversed on count overflow

### DIFF
--- a/fw/analog_button.cpp
+++ b/fw/analog_button.cpp
@@ -14,9 +14,9 @@ int8_t AnalogButton::poll(uint8_t deadzone, uint8_t sustain_ms, const uint8_t cu
   int8_t delta = current_value - center;
   // Handle wrap-around cases
   if (delta > 127) {
-    delta = (delta - 256) * -1;
+    delta = delta - 256;
   } else if (delta < -127) {
-    delta = (delta + 256) * -1;
+    delta = delta + 256;
   }
 
   // is the current value sufficiently far away from the center?
@@ -37,7 +37,9 @@ int8_t AnalogButton::poll(uint8_t deadzone, uint8_t sustain_ms, const uint8_t cu
     // disable deadzone to increase sensitivity to direction changes
     deadzone = 1;
     direction_change = direction == -state;
-  } else if (timer_is_expired(&sustain_timer)) {
+  } else if (timer_is_active(&sustain_timer)) {
+    deadzone = 1;
+  } else {
     // sustain timer expired, time to reset to neutral
     state = 0;
   }


### PR DESCRIPTION
Found these bugs while working on ARM firmware. Fixes are already on the `rp2350b` branch, just being ported over to the AVR firmware.

* When the analog position counter under/overflows the delta sign was being incorrectly reversed, such that it would reverse the direction for one tick
* While the TT/pots are being turned, the deadzone is supposed to be set to 1 to give direction turns maximum sensitivity. This was instead being entirely ignored and the deadzone was still being set to the configured setting.